### PR TITLE
Fix search and hashtag video scraping for zendriver

### DIFF
--- a/examples/hashtag_example.py
+++ b/examples/hashtag_example.py
@@ -1,21 +1,87 @@
+import argparse
 import asyncio
 import json
+import logging
+import os
 
 from pytok.tiktok import PyTok
 
-hashtag_name = 'fyp'
 
-async def main():
-    async with PyTok(manual_captcha_solves=True) as api:
+async def scrape_hashtag(hashtag_name, count, output, chrome_profile, username, password, headless):
+    pytok_kwargs = {"headless": headless}
+    if chrome_profile:
+        # A Chrome user-data dir that is already signed in to TikTok. Reusing it
+        # avoids logging in every run and persists the session across runs.
+        pytok_kwargs["user_data_dir"] = os.path.expanduser(chrome_profile)
+
+    async with PyTok(**pytok_kwargs) as api:
+        # Hashtag video listing requires a logged-in session: TikTok's
+        # challenge/item_list endpoint returns empty responses for anonymous
+        # sessions, and the web hashtag feed is login-walled.
+        if chrome_profile:
+            # The profile already carries a logged-in session; with no
+            # credentials login() just verifies and refreshes the API tokens.
+            await api.login()
+        elif username and password:
+            await api.login(username=username, password=password)
+        else:
+            logging.warning(
+                "No --chrome-profile or credentials supplied. TikTok requires "
+                "login to list hashtag videos, so this will likely return nothing."
+            )
+
         hashtag = api.hashtag(name=hashtag_name)
 
         videos = []
-        async for video in hashtag.videos(count=1000):
+        async for video in hashtag.videos(count=count):
             video_info = await video.info()
             videos.append(video_info)
 
-        with open("out.json", "w") as out_file:
+        with open(output, "w") as out_file:
             json.dump(videos, out_file)
 
+        logging.info("Saved %d videos for #%s to %s", len(videos), hashtag_name, output)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scrape videos for a TikTok hashtag (requires a logged-in session)."
+    )
+    parser.add_argument("--hashtag", default="fyp", help="Hashtag name, without the leading '#'.")
+    parser.add_argument("--count", type=int, default=100, help="Maximum number of videos to fetch.")
+    parser.add_argument("--output", default="out.json", help="Path to write the JSON results to.")
+    parser.add_argument(
+        "--chrome-profile",
+        default=os.environ.get("TIKTOK_CHROME_PROFILE"),
+        help="Path to a Chrome user-data dir already signed in to TikTok "
+             "(or set the TIKTOK_CHROME_PROFILE env var). Pass it at runtime so "
+             "your profile path never ends up in source control.",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.environ.get("TIKTOK_USERNAME"),
+        help="TikTok username/email for an automatic login (or set TIKTOK_USERNAME). "
+             "Used only when --chrome-profile is not given.",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("TIKTOK_PASSWORD"),
+        help="TikTok password (or set TIKTOK_PASSWORD). Used only when "
+             "--chrome-profile is not given.",
+    )
+    parser.add_argument("--headless", action="store_true", help="Run the browser headless.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    asyncio.run(scrape_hashtag(
+        args.hashtag, args.count, args.output,
+        args.chrome_profile, args.username, args.password, args.headless,
+    ))
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/examples/search_example.py
+++ b/examples/search_example.py
@@ -1,0 +1,90 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+
+from pytok.tiktok import PyTok
+
+
+async def scrape_search(search_term, search_type, count, output, chrome_profile, username, password, headless):
+    pytok_kwargs = {"headless": headless}
+    if chrome_profile:
+        # A Chrome user-data dir that is already signed in to TikTok. Reusing it
+        # avoids logging in every run and persists the session across runs.
+        pytok_kwargs["user_data_dir"] = os.path.expanduser(chrome_profile)
+
+    async with PyTok(**pytok_kwargs) as api:
+        # User search works without logging in, but video search requires a
+        # logged-in session: TikTok's search/item endpoint returns empty
+        # responses for anonymous sessions, and the web search feed is
+        # login-walled.
+        if chrome_profile:
+            # The profile already carries a logged-in session; with no
+            # credentials login() just verifies and refreshes the API tokens.
+            await api.login()
+        elif username and password:
+            await api.login(username=username, password=password)
+        elif search_type == "video":
+            logging.warning(
+                "No --chrome-profile or credentials supplied. TikTok requires "
+                "login to search videos, so this will likely return nothing."
+            )
+
+        search = api.search(search_term)
+        source = search.users(count=count) if search_type == "user" else search.videos(count=count)
+
+        results = []
+        async for result in source:
+            results.append(await result.info())
+
+        with open(output, "w") as out_file:
+            json.dump(results, out_file)
+
+        logging.info("Saved %d %s results for '%s' to %s", len(results), search_type, search_term, output)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search TikTok for videos or users (video search requires a logged-in session)."
+    )
+    parser.add_argument("--term", default="therock", help="The phrase to search for.")
+    parser.add_argument("--type", default="video", choices=["video", "user"],
+                        help="Search for videos or users.")
+    parser.add_argument("--count", type=int, default=100, help="Maximum number of results to fetch.")
+    parser.add_argument("--output", default="out.json", help="Path to write the JSON results to.")
+    parser.add_argument(
+        "--chrome-profile",
+        default=os.environ.get("TIKTOK_CHROME_PROFILE"),
+        help="Path to a Chrome user-data dir already signed in to TikTok "
+             "(or set the TIKTOK_CHROME_PROFILE env var). Pass it at runtime so "
+             "your profile path never ends up in source control.",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.environ.get("TIKTOK_USERNAME"),
+        help="TikTok username/email for an automatic login (or set TIKTOK_USERNAME). "
+             "Used only when --chrome-profile is not given.",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("TIKTOK_PASSWORD"),
+        help="TikTok password (or set TIKTOK_PASSWORD). Used only when "
+             "--chrome-profile is not given.",
+    )
+    parser.add_argument("--headless", action="store_true", help="Run the browser headless.")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+
+    asyncio.run(scrape_search(
+        args.term, args.type, args.count, args.output,
+        args.chrome_profile, args.username, args.password, args.headless,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/pytok/api/hashtag.py
+++ b/pytok/api/hashtag.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
+import asyncio
 import json
-import urllib.parse
 
 from typing import TYPE_CHECKING, ClassVar, Iterator, Optional
 
-import requests
+from zendriver import cdp
 
 if TYPE_CHECKING:
     from ..tiktok import PyTok
     from .video import Video
 
 from .base import Base
-from ..helpers import edit_url, extract_tag_contents
 from ..exceptions import *
 
 
@@ -67,31 +66,73 @@ class Hashtag(Base):
 
         Example Usage
         ```py
-        hashtag_data = api.hashtag(name='funny').info_full()
+        hashtag_data = await api.hashtag(name='funny').info_full()
         ```
         """
+        try:
+            return await self._info_full_api(**kwargs)
+        except ApiFailedException as ex:
+            self.parent.logger.warning(
+                f"TikTok-Api hashtag.info_full() failed: {ex}. Falling back to scraping method."
+            )
+            return await self._info_full_scrape(**kwargs)
+
+    async def _info_full_api(self, **kwargs) -> dict:
+        if not self.name:
+            raise TypeError(
+                "You must provide the name when creating this class to use this method."
+            )
+
+        url_params = {
+            "challengeName": self.name,
+        }
+
+        try:
+            resp = await self.parent.tiktok_api.make_request(
+                url="https://www.tiktok.com/api/challenge/detail/",
+                params=url_params,
+            )
+        except EmptyResponseException:
+            raise ApiFailedException("TikTok API returned empty response")
+        except Exception as e:
+            raise ApiFailedException(f"TikTok-Api make_request failed: {e}")
+
+        if resp is None:
+            raise ApiFailedException("TikTok returned None response")
+
+        if 'challengeInfo' not in resp:
+            raise ApiFailedException("Failed to get challengeInfo from response")
+
+        self.as_dict = resp['challengeInfo']
+        self.__extract_from_data()
+        return self.as_dict
+
+    async def _info_full_scrape(self, **kwargs) -> dict:
         page = self.parent._page
 
         url = f"https://www.tiktok.com/tag/{self.name}"
-        await page.goto(url)
+        self.parent.logger.debug(f"Loading page: {url}")
+        await page.send(cdp.page.navigate(url))
+        async with asyncio.timeout(30):
+            await page.wait_for_ready_state(until='complete', timeout=31)
+        await asyncio.sleep(3)  # Brief wait for dynamic content
 
+        await self.parent.process_pending_responses()
         await self.wait_for_content_or_unavailable_or_captcha('[data-e2e=challenge-item]', 'Not available')
         await self.check_and_close_signin()
 
-        challenge_responses = self.get_responses("api/challenge/detail")
-        challenge_responses = [request for request in challenge_responses if f"challengeName={urllib.parse.quote_plus(self.name)}" in request.url]
+        challenge_responses = await self.parent.process_pending_responses("api/challenge/detail")
         if len(challenge_responses) == 0:
-            raise ApiFailedException("Failed to get challenge request")
-        else:
-            challenge_response = challenge_responses[0]
+            raise ApiFailedException("Failed to get challenge response")
 
-        rep_body = await self.get_response_body(challenge_response)
-        rep_d = json.loads(rep_body.decode('utf-8'))
+        rep_body = challenge_responses[0].get('body', '')
+        rep_d = json.loads(rep_body) if isinstance(rep_body, str) else rep_body
 
         if 'challengeInfo' not in rep_d:
             raise ApiFailedException("Failed to get challengeInfo from response")
 
         self.as_dict = rep_d['challengeInfo']
+        self.__extract_from_data()
         return self.as_dict
 
     async def videos(self, count=30, offset=0, **kwargs) -> Iterator[Video]:
@@ -103,7 +144,7 @@ class Hashtag(Base):
 
         Example Usage
         ```py
-        for video in api.hashtag(name='funny').videos():
+        async for video in api.hashtag(name='funny').videos():
             # do something
         ```
         """
@@ -112,94 +153,148 @@ class Hashtag(Base):
         try:
             async for video in self._get_videos_api(count, offset, **kwargs):
                 yield video
-        except ApiFailedException:
+        except ApiFailedException as ex:
+            self.parent.logger.warning(
+                f"TikTok-Api hashtag.videos() failed: {ex}. Falling back to scraping method."
+            )
             async for video in self._get_videos_scraping(count, offset, **kwargs):
                 yield video
 
-
-    async def _get_videos_scraping(self, count=30, offset=0, **kwargs):
-        processed_urls = []
+    async def _get_videos_api(self, count=30, offset=0, **kwargs):
         amount_yielded = 0
-        pull_method = 'browser'
-        tries = 0
-        MAX_TRIES = 5
-        data_request_path = "api/challenge/item_list"
+        cursor = offset
 
         while amount_yielded < count:
+            params = {
+                "challengeID": self.id,
+                "count": 35,
+                "cursor": cursor,
+            }
+
+            try:
+                res = await self.parent.tiktok_api.make_request(
+                    url="https://www.tiktok.com/api/challenge/item_list/",
+                    params=params,
+                )
+            except Exception as e:
+                raise ApiFailedException(f"TikTok-Api make_request failed: {e}")
+
+            if res is None:
+                raise ApiFailedException("TikTok-Api returned None response")
+
+            if res.get('type') == 'verify':
+                raise ApiFailedException("TikTok API is asking for verification")
+
+            # challenge/item_list needs anti-bot params (verifyFp etc.) that
+            # make_request doesn't add, so it often returns a non-zero status
+            # with no items. Treat that as a failure so we fall back to scraping.
+            status_code = res.get('statusCode', 0)
+            if status_code != 0:
+                raise ApiFailedException(
+                    f"TikTok returned error for hashtag videos: statusCode={status_code}"
+                )
+
+            videos = res.get("itemList", [])
+            for video in videos:
+                yield self.parent.video(data=video)
+                amount_yielded += 1
+                if amount_yielded >= count:
+                    return
+
+            if not res.get("hasMore", False):
+                self.parent.logger.info(
+                    "TikTok isn't sending more TikToks beyond this point."
+                )
+                return
+
+            cursor = res.get("cursor", cursor)
             await self.parent.request_delay()
 
-            search_requests = self.get_requests(data_request_path)
-            search_requests = [response for response in search_requests if f"challengeID={self.as_dict['challenge']['id']}" in response.url]
-            search_requests = [request for request in search_requests if request.url not in processed_urls]
-            for request in search_requests:
-                processed_urls.append(request.url)
-                response = await request.response()
+    async def _get_videos_scraping(self, count=30, offset=0, **kwargs):
+        page = self.parent._page
+
+        # Ensure we're on the hashtag page so item_list requests fire as we scroll
+        url = f"https://www.tiktok.com/tag/{self.name}"
+        self.parent.logger.debug(f"Loading page: {url}")
+        await page.send(cdp.page.navigate(url))
+        async with asyncio.timeout(30):
+            await page.wait_for_ready_state(until='complete', timeout=31)
+        await asyncio.sleep(3)
+
+        await self.parent.process_pending_responses()
+        await self.check_and_wait_for_captcha()
+        await self.check_and_close_signin()
+        if not await self._is_selector_visible('[data-e2e=challenge-item]'):
+            self.parent.logger.warning(
+                "Hashtag video grid not visible yet (TikTok requires login for this "
+                "feed; pass a logged-in user_data_dir if you get no results)."
+            )
+
+        amount_yielded = 0
+        seen_ids = set()
+        has_more = True
+        scroll_attempts = 0
+        max_scroll_attempts = 30
+        empty_rounds = 0
+        max_empty_rounds = 5
+
+        while amount_yielded < count and has_more and scroll_attempts < max_scroll_attempts:
+            await self.check_and_wait_for_captcha()
+
+            # Scroll first so the lazily-loaded item_list request fires, then give
+            # its response body time to be captured before reading it.
+            yielded_before = amount_yielded
+            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
+            await asyncio.sleep(3)
+            await self.check_and_resolve_refresh_button()
+
+            video_responses = await self.parent.process_pending_responses("api/challenge/item_list")
+            for resp in video_responses:
+                body = resp.get('body', '')
+                if not body:
+                    continue
                 try:
-                    body = await self.get_response_body(response)
-                    res = json.loads(body)
-                except:
+                    res = json.loads(body) if isinstance(body, str) else body
+                except json.JSONDecodeError:
                     continue
                 if res.get('type') == 'verify':
                     # this is the captcha denied response
                     continue
 
-                videos = res.get("itemList", [])
-                amount_yielded += len(videos)
-                for video in videos:
+                for video in res.get("itemList", []):
+                    video_id = video.get('id')
+                    if video_id and video_id in seen_ids:
+                        continue
+                    if video_id:
+                        seen_ids.add(video_id)
                     yield self.parent.video(data=video)
+                    amount_yielded += 1
+                    if amount_yielded >= count:
+                        return
 
                 if not res.get("hasMore", False):
                     self.parent.logger.info(
                         "TikTok isn't sending more TikToks beyond this point."
                     )
-                    return
+                    has_more = False
 
-            for _ in range(tries):
-                await self.slight_scroll_up()
-                await self.scroll_to_bottom()
-                await self.parent.request_delay()
-            
-                search_requests = self.get_requests(data_request_path)
-                search_requests = [request for request in search_requests if request.url not in processed_urls]
+            if not has_more:
+                break
 
-            if len(search_requests) == 0:
-                tries += 1
-                if tries > MAX_TRIES:
-                    raise
-                continue
-                
-
-    async def _get_videos_api(self, count=30, offset=0, **kwargs):
-        responses = self.get_responses("api/challenge/item_list")
-        responses = [response for response in responses if f"challengeID={self.as_dict['challenge']['id']}" in response.url]
-
-        amount_yielded = 0
-        cursor = 0
-        while amount_yielded < count:
-            for response in responses:
-                next_url = edit_url(response.url, {"cursor": cursor})
-                cookies = await self.parent._context.cookies()
-                cookies = {cookie['name']: cookie['value'] for cookie in cookies}
-                r = requests.get(next_url, headers=response.headers, cookies=cookies)
-                if len(r.content) == 0:
-                    raise ApiFailedException("Response had no body")
-                try:
-                    res = r.json()
-                except json.decoder.JSONDecodeError:
-                    raise InvalidJSONException
-
-                cursor = res["cursor"]
-                videos = res.get("itemList", [])
-
-                amount_yielded += len(videos)
-                for video in videos:
-                    yield self.parent.video(data=video)
-
-                if not res.get("hasMore", False):
+            # Give up early if scrolling stops producing new videos (e.g. the
+            # feed is login-walled) rather than scrolling to the hard limit.
+            if amount_yielded == yielded_before:
+                empty_rounds += 1
+                if empty_rounds >= max_empty_rounds:
                     self.parent.logger.info(
-                        "TikTok isn't sending more TikToks beyond this point."
+                        "No new hashtag videos after repeated scrolls, stopping."
                     )
                     return
+            else:
+                empty_rounds = 0
+
+            await self.parent.request_delay()
+            scroll_attempts += 1
 
     def __extract_from_data(self):
         data = self.as_dict
@@ -208,6 +303,10 @@ class Hashtag(Base):
         if "title" in keys:
             self.id = data["id"]
             self.name = data["title"]
+
+        if "challenge" in keys:
+            self.id = data["challenge"]["id"]
+            self.name = data["challenge"]["title"]
 
         if None in (self.name, self.id):
             Hashtag.parent.logger.error(
@@ -219,12 +318,3 @@ class Hashtag(Base):
 
     def __str__(self):
         return f"PyTok.hashtag(id='{self.id}', name='{self.name}')"
-
-    def __getattr__(self, name):
-        # TODO: Maybe switch to using @property instead
-        if name in ["id", "name", "as_dict"]:
-            self.as_dict = self.info()
-            self.__extract_from_data()
-            return self.__getattribute__(name)
-
-        raise AttributeError(f"{name} doesn't exist on PyTok.api.Hashtag")

--- a/pytok/api/search.py
+++ b/pytok/api/search.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import json
-import time
-from typing import TYPE_CHECKING, Iterator, Type
-from urllib.parse import urlencode
-import re
+import urllib.parse
+from typing import TYPE_CHECKING, Iterator
+
+from zendriver import cdp
 
 from .user import User
-from .hashtag import Hashtag
 from .video import Video
 from .base import Base
 from ..exceptions import *
@@ -15,161 +15,209 @@ from ..exceptions import *
 if TYPE_CHECKING:
     from ..tiktok import PyTok
 
-import requests
+# web_search_code mirrors what the TikTok web app sends with search requests
+_WEB_SEARCH_CODE = '{"tiktok":{"client_params_x":{"search_engine":{"ies_mt_user_live_video_card_use_libra":1,"mt_search_general_user_live_card":1}},"search_server":{}}}'
+
 
 class Search(Base):
-    """Contains static methods about searching."""
+    """Contains methods for searching TikTok."""
 
     parent: PyTok
 
     def __init__(self, search_term):
         self.search_term = search_term
 
-    def videos(self, count=28, offset=0, **kwargs) -> Iterator[Video]:
+    async def videos(self, count=28, offset=0, **kwargs) -> Iterator[Video]:
         """
         Searches for Videos
 
         - Parameters:
-            - search_term (str): The phrase you want to search for.
             - count (int): The amount of videos you want returned.
             - offset (int): The offset of videos from your data you want returned.
 
         Example Usage
         ```py
-        for video in api.search.videos('therock'):
+        async for video in api.search('therock').videos():
             # do something
         ```
         """
-        return self.search_type(
-            "item", count=count, offset=offset, **kwargs
-        )
+        async for result in self.search_type("item", count=count, offset=offset, **kwargs):
+            yield result
 
-    def users(self, count=28, offset=0, **kwargs) -> Iterator[User]:
+    async def users(self, count=28, offset=0, **kwargs) -> Iterator[User]:
         """
-        Searches for users using an alternate endpoint than Search.users
+        Searches for users.
 
         - Parameters:
-            - search_term (str): The phrase you want to search for.
-            - count (int): The amount of videos you want returned.
+            - count (int): The amount of users you want returned.
+            - offset (int): The offset of users from your data you want returned.
 
         Example Usage
         ```py
-        for user in api.search.users_alternate('therock'):
+        async for user in api.search('therock').users():
             # do something
         ```
         """
-        return self.search_type(
-            "user", count=count, offset=offset, **kwargs
-        )
+        async for result in self.search_type("user", count=count, offset=offset, **kwargs):
+            yield result
 
     async def search_type(self, obj_type, count=28, offset=0, **kwargs) -> Iterator:
         """
-        Searches for users using an alternate endpoint than Search.users
+        Searches for a specific type of object. Use .videos() & .users() instead.
 
         - Parameters:
-            - search_term (str): The phrase you want to search for.
-            - count (int): The amount of videos you want returned.
+            - count (int): The amount of objects you want returned.
+            - offset (int): The offset of objects you want returned.
             - obj_type (str): user | item
-
-        Just use .video & .users
-        ```
         """
-
-        if obj_type == "user":
-            subdomain = "www"
-            subpath = "user"
-        elif obj_type == "item":
-            subdomain = "www"
-            subpath = "video"
-        else:
+        if obj_type not in ("user", "item"):
             raise TypeError("invalid obj_type")
 
-        page = self.parent._page
+        try:
+            async for result in self._search_type_api(obj_type, count=count, offset=offset, **kwargs):
+                yield result
+        except ApiFailedException as ex:
+            self.parent.logger.warning(
+                f"TikTok-Api search ({obj_type}) failed: {ex}. Falling back to scraping method."
+            )
+            async for result in self._search_type_scraping(obj_type, count=count, offset=offset, **kwargs):
+                yield result
 
-        url = f"https://{subdomain}.tiktok.com/search/{subpath}?q={self.search_term}"
-        await page.goto(url)
-
-        is_visible = await page.locator('[data-e2e="search_video-item"]').is_visible()
-        is_visible2 = await page.locator('[data-e2e="search_video-item-list"]').is_visible()
-        is_visible3 = await page.locator('[id="column-item-video-container-0"]').is_visible()
-
-        await self.wait_for_content_or_captcha('[id="column-item-video-container-0"]')
-
-        processed_urls = []
+    async def _search_type_api(self, obj_type, count=28, offset=0, **kwargs) -> Iterator:
         amount_yielded = 0
-        pull_method = 'browser'
-        
-        path = f"api/search/{obj_type}"
+        cursor = offset
 
         while amount_yielded < count:
+            params = {
+                "keyword": self.search_term,
+                "cursor": cursor,
+                "from_page": "search",
+                "web_search_code": _WEB_SEARCH_CODE,
+            }
+
+            try:
+                res = await self.parent.tiktok_api.make_request(
+                    url=f"https://www.tiktok.com/api/search/{obj_type}/full/",
+                    params=params,
+                )
+            except Exception as e:
+                raise ApiFailedException(f"TikTok-Api make_request failed: {e}")
+
+            if res is None:
+                raise ApiFailedException("TikTok-Api returned None response")
+
+            if res.get('type') == 'verify':
+                raise ApiFailedException("TikTok API is asking for verification")
+
+            for result in self._yield_results(obj_type, res):
+                yield result
+                amount_yielded += 1
+                if amount_yielded >= count:
+                    return
+
+            if not res.get("has_more", 0):
+                self.parent.logger.info(
+                    "TikTok is not sending results beyond this point."
+                )
+                return
+
+            cursor = res.get("cursor", cursor)
+            await self.parent.request_delay()
+
+    async def _search_type_scraping(self, obj_type, count=28, offset=0, **kwargs) -> Iterator:
+        page = self.parent._page
+
+        subpath = "user" if obj_type == "user" else "video"
+        url = f"https://www.tiktok.com/search/{subpath}?q={urllib.parse.quote(self.search_term)}"
+        self.parent.logger.debug(f"Loading page: {url}")
+        await page.send(cdp.page.navigate(url))
+        async with asyncio.timeout(30):
+            await page.wait_for_ready_state(until='complete', timeout=31)
+        await asyncio.sleep(3)
+
+        await self.parent.process_pending_responses()
+        await self.check_and_wait_for_captcha()
+        await self.check_and_close_signin()
+
+        amount_yielded = 0
+        seen_ids = set()
+        has_more = True
+        scroll_attempts = 0
+        max_scroll_attempts = 30
+        empty_rounds = 0
+        max_empty_rounds = 3
+
+        while amount_yielded < count and has_more and scroll_attempts < max_scroll_attempts:
             await self.check_and_wait_for_captcha()
-            await self.parent.request_delay()
-            await self.slight_scroll_up()
-            await self.parent.request_delay()
-            await self.scroll_down(30000, speed=12)
 
-            if pull_method == 'browser':
-                search_responses = self.get_responses(path)
-                search_responses = [response for response in search_responses if response.url not in processed_urls]
-                for response in search_responses:
-                    processed_urls.append(response.url)
-                    body = await self.get_response_body(response)
-                    if not body:
-                        continue
-                    res = json.loads(body)
-                    if res.get('type') == 'verify':
-                        # this is the captcha denied response
-                        continue
+            # Scroll first so the lazily-loaded search request fires, then give
+            # its response body time to be captured before reading it.
+            yielded_before = amount_yielded
+            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
+            await asyncio.sleep(3)
+            await self.check_and_resolve_refresh_button()
 
-                    # When I move to 3.10+ support make this a match switch.
-                    if obj_type == "user":
-                        for result in res.get("user_list", []):
-                            yield User(data=result)
-                            amount_yielded += 1
-
-                    if obj_type == "item":
-                        for result in res.get("item_list", []):
-                            yield Video(data=result)
-                            amount_yielded += 1
-
-                    if res.get("has_more", 0) == 0:
-                        Search.parent.logger.info(
-                            "TikTok is not sending videos beyond this point."
-                        )
-                        return
-
-                # try:
-                #     load_more_button = await self.wait_for_content_or_captcha('search-load-more')
-                # except TimeoutError:
-                #     return
-
-                # await load_more_button.click()
-
-            
-            elif pull_method == 'requests':
-                cursor = res["cursor"]
-                next_url = re.sub("offset=([0-9]+)", f"offset={cursor}", request.url)
-                cookies = self.parent._context.cookies()
-                cookies = {cookie['name']: cookie['value'] for cookie in cookies}
-                r = requests.get(next_url, headers=request.headers, cookies=cookies)
-                res = r.json()
-
+            responses = await self.parent.process_pending_responses("api/search/")
+            for resp in responses:
+                body = resp.get('body', '')
+                if not body:
+                    continue
+                try:
+                    res = json.loads(body) if isinstance(body, str) else body
+                except json.JSONDecodeError:
+                    continue
                 if res.get('type') == 'verify':
-                    pull_method = 'browser'
+                    # this is the captcha denied response
                     continue
 
-                if obj_type == "user":
-                    for result in res.get("user_list", []):
-                        yield User(data=result)
-                        amount_yielded += 1
+                for result, result_id in self._yield_results(obj_type, res, with_id=True):
+                    if result_id and result_id in seen_ids:
+                        continue
+                    if result_id:
+                        seen_ids.add(result_id)
+                    yield result
+                    amount_yielded += 1
+                    if amount_yielded >= count:
+                        return
 
-                if obj_type == "item":
-                    for result in res.get("item_list", []):
-                        yield Video(data=result)
-                        amount_yielded += 1
-
-                if res.get("has_more", 0) == 0:
+                if not res.get("has_more", 0):
                     self.parent.logger.info(
-                        "TikTok is not sending videos beyond this point."
+                        "TikTok is not sending results beyond this point."
+                    )
+                    has_more = False
+
+            if not has_more:
+                break
+
+            # Give up early if scrolling stops producing new results rather than
+            # scrolling all the way to the hard limit.
+            if amount_yielded == yielded_before:
+                empty_rounds += 1
+                if empty_rounds >= max_empty_rounds:
+                    self.parent.logger.info(
+                        "No new search results after repeated scrolls, stopping."
                     )
                     return
+            else:
+                empty_rounds = 0
+
+            await self.parent.request_delay()
+            scroll_attempts += 1
+
+    def _yield_results(self, obj_type, res, with_id=False):
+        """Build User/Video objects from a search response payload."""
+        if obj_type == "user":
+            for result in res.get("user_list", []):
+                info = result.get("user_info", {})
+                obj = self.parent.user(
+                    username=info.get("unique_id"),
+                    user_id=info.get("user_id") or info.get("uid"),
+                    sec_uid=info.get("sec_uid"),
+                )
+                result_id = info.get("user_id") or info.get("uid")
+                yield (obj, result_id) if with_id else obj
+        else:
+            for result in res.get("item_list", []):
+                obj = self.parent.video(data=result)
+                result_id = result.get("id")
+                yield (obj, result_id) if with_id else obj

--- a/pytok/tiktok_api.py
+++ b/pytok/tiktok_api.py
@@ -470,7 +470,13 @@ class ZendriverTikTokApi:
 
     def generate_js_fetch(self, method: str, url: str, headers: dict) -> str:
         """Generate a JS fetch IIFE for zendriver evaluate."""
-        headers_js = json.dumps(headers)
+        # fetch() rejects a null headers value or non-string header values, so
+        # coerce to a clean string->string dict (headers may be None for some
+        # sessions, e.g. when loaded from a logged-in Chrome profile).
+        clean_headers = {
+            str(k): str(v) for k, v in (headers or {}).items() if v is not None
+        }
+        headers_js = json.dumps(clean_headers)
         return (
             f"(async () => {{"
             f"  const resp = await fetch('{url}', {{ method: '{method}', headers: {headers_js} }});"


### PR DESCRIPTION
## Summary

`search.py` and `hashtag.py` were left behind in the zendriver migration (commit `2eaf04b`). They still used Playwright APIs (`page.goto`, `page.locator`) and accessed CDP responses as objects (`response.url`) when they're now plain dicts — so both crashed immediately (`'Tab' object has no attribute 'goto'`).

This rewrites both to the working `user.py`/`video.py` pattern: **API-first via `tiktok_api.make_request`, with a browser-scraping fallback** that scrolls and captures `item_list`/`search` XHRs via `process_pending_responses`.

## Changes

- **`pytok/api/search.py`** — `Search.users()`/`Search.videos()` ported to zendriver; API-first with scraping fallback. `users()`/`videos()` are now async generators.
- **`pytok/api/hashtag.py`** — `info()` and `videos()` ported; `info` is API-first. `_get_videos_api` now raises `ApiFailedException` on a non-zero `statusCode` (e.g. `100002` from `challenge/item_list`, which needs `verifyFp`/`clientABVersions` params `make_request` doesn't send) so the scraping fallback actually triggers. Removed a stale content-wait that navigated away to the homepage.
- **`pytok/tiktok_api.py`** — `generate_js_fetch` crashed (*"Failed to read the 'headers' property"*) because `session.headers` is `None` for profile-loaded sessions and `json.dumps(None)` → `headers: null`. Now coerces headers to a clean string→string dict.
- **`examples/hashtag_example.py`** — takes the logged-in Chrome profile (or credentials) via `--chrome-profile` / `TIKTOK_CHROME_PROFILE` (or `--username`/`--password`) so no profile path lands in source.

## Behaviour / caveats

- `Search.users()` works anonymously.
- `Search.videos()` and `Hashtag.videos()` require a **logged-in session** — anonymous access to those endpoints is bot-blocked by TikTok (empty responses). With a logged-in `user_data_dir`, they fall back to scraping the feed, which works.
- That profile must run **non-headless** — headless lands the session tab on `chrome-error://` and every request fails.

## Verified end-to-end (logged-in profile, non-headless)

| Method | Result |
|---|---|
| `hashtag('funny').videos(count=25)` | 25 videos with real IDs |
| `search('therock').videos(count=15)` | 12 videos |
| `search('therock').users()` | works (also anonymously) |
| `hashtag.info()` | works |

🤖 Generated with [Claude Code](https://claude.com/claude-code)