### PR TITLE
Fix multi-worker race: bind API objects to their PyTok instance

### DIFF
--- a/pytok/accounts/worker.py
+++ b/pytok/accounts/worker.py
@@ -77,14 +77,11 @@ class Worker:
         self.tasks_per_rest = tasks_per_rest
         self.max_retries = max_retries
         self.pytok_kwargs = pytok_kwargs or {}
-        # One-shot delay before this worker builds its FIRST session. The pool
-        # staggers workers (worker-0: 0s, worker-1: Ns, ...) so their browser
-        # startups don't overlap. Each worker has its OWN browser/tab/session
-        # (nothing is shared between workers), but launching two zendriver
-        # Chrome instances at the same instant intermittently leaves one
-        # PyTok's API client without a created session ("No sessions created"
-        # on the first request). Mitigation, not a proven root-cause fix; the
-        # in-place session rebuild in execute_task is what actually recovers it.
+        # One-shot delay before this worker builds its FIRST session. Optional
+        # extra jitter only (default 0): concurrent launches are serialized by
+        # PyTok's shared startup_lock, and the old cross-worker "No sessions
+        # created" race is gone now that API objects bind `parent` per PyTok
+        # instance instead of via a shared class attribute.
         self.startup_delay = startup_delay
         self._startup_delayed = False
 
@@ -237,8 +234,7 @@ class Worker:
                 await self._close_session()
 
             except Exception as e:
-                # Unknown error / browser crash / transient session-setup race
-                # (e.g. "No sessions created" when two browsers start at once).
+                # Unknown error / browser crash / transient session failure.
                 # Drop the (probably dead) session and rebuild IN PLACE on the
                 # same account — these recover on a fresh session in seconds.
                 # We deliberately do NOT rotate+cooldown here: with a small pool

--- a/pytok/api/hashtag.py
+++ b/pytok/api/hashtag.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 
-from typing import TYPE_CHECKING, ClassVar, Iterator, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from zendriver import cdp
 
@@ -25,7 +25,8 @@ class Hashtag(Base):
     ```
     """
 
-    parent: ClassVar[PyTok]
+    parent: PyTok
+    """The PyTok instance this object is bound to (set by api.hashtag(...))."""
 
     id: Optional[str]
     """The ID of the hashtag"""
@@ -39,10 +40,12 @@ class Hashtag(Base):
         name: Optional[str] = None,
         id: Optional[str] = None,
         data: Optional[dict] = None,
+        parent: Optional[PyTok] = None,
     ):
         """
         You must provide the name or id of the hashtag.
         """
+        self.parent = parent
         self.name = name
         self.id = id
 
@@ -309,7 +312,7 @@ class Hashtag(Base):
             self.name = data["challenge"]["title"]
 
         if None in (self.name, self.id):
-            Hashtag.parent.logger.error(
+            self.parent.logger.error(
                 f"Failed to create Hashtag with data: {data}\nwhich has keys {data.keys()}"
             )
 

--- a/pytok/api/search.py
+++ b/pytok/api/search.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import urllib.parse
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from zendriver import cdp
 
@@ -39,8 +39,10 @@ class Search(Base):
     """Contains methods for searching TikTok."""
 
     parent: PyTok
+    """The PyTok instance this object is bound to (set by api.search(...))."""
 
-    def __init__(self, search_term):
+    def __init__(self, search_term, parent: Optional[PyTok] = None):
+        self.parent = parent
         self.search_term = search_term
 
     async def videos(self, count=28, offset=0, **kwargs) -> Iterator[Video]:

--- a/pytok/api/sound.py
+++ b/pytok/api/sound.py
@@ -8,7 +8,7 @@ from urllib.parse import quote, urlencode
 from ..helpers import extract_tag_contents
 from ..exceptions import *
 
-from typing import TYPE_CHECKING, ClassVar, Iterator, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 if TYPE_CHECKING:
     from ..tiktok import PyTok
@@ -26,7 +26,8 @@ class Sound:
     ```
     """
 
-    parent: ClassVar[PyTok]
+    parent: PyTok
+    """The PyTok instance this object is bound to (set by api.sound(...))."""
 
     id: str
     """TikTok's ID for the sound"""
@@ -35,10 +36,16 @@ class Sound:
     author: Optional[User]
     """The author of the song (if it exists)"""
 
-    def __init__(self, id: Optional[str] = None, data: Optional[str] = None):
+    def __init__(
+        self,
+        id: Optional[str] = None,
+        data: Optional[str] = None,
+        parent: Optional[PyTok] = None,
+    ):
         """
         You must provide the id of the sound or it will not work.
         """
+        self.parent = parent
         if data is not None:
             self.as_dict = data
             self.__extract_from_data()
@@ -105,7 +112,7 @@ class Sound:
             self.author = self.parent.user(username=data["authorName"])
 
         if self.id is None:
-            Sound.parent.logger.error(
+            self.parent.logger.error(
                 f"Failed to create Sound with data: {data}\nwhich has keys {data.keys()}"
             )
 

--- a/pytok/api/trending.py
+++ b/pytok/api/trending.py
@@ -8,16 +8,20 @@ from .sound import Sound
 from .user import User
 from .hashtag import Hashtag
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Iterator, Optional
 
 if TYPE_CHECKING:
     from ..tiktok import PyTok
 
 
 class Trending:
-    """Contains static methods related to trending."""
+    """Contains methods related to trending."""
 
     parent: PyTok
+    """The PyTok instance this object is bound to (set by api.trending(...))."""
+
+    def __init__(self, parent: Optional[PyTok] = None):
+        self.parent = parent
 
     @staticmethod
     def videos(count=30, **kwargs) -> Iterator[Video]:

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING, ClassVar, Iterator, Optional
+from typing import TYPE_CHECKING, Iterator, Optional
 
 from zendriver import cdp
 
@@ -31,7 +31,8 @@ class User(Base):
 
     """
 
-    parent: ClassVar[PyTok]
+    parent: PyTok
+    """The PyTok instance this object is bound to (set by api.user(...))."""
 
     user_id: str
     """The user ID of the user."""
@@ -48,11 +49,13 @@ class User(Base):
             user_id: Optional[str] = None,
             sec_uid: Optional[str] = None,
             data: Optional[dict] = None,
+            parent: Optional[PyTok] = None,
     ):
         """
         You must provide the username or (user_id and sec_uid) otherwise this
         will not function correctly.
         """
+        self.parent = parent
         self.__update_id_sec_uid_username(user_id, sec_uid, username)
         self._used_api_for_info = False
         if data is not None:
@@ -571,7 +574,7 @@ class User(Base):
             # do something
         ```
         """
-        processed = User.parent._process_kwargs(kwargs)
+        processed = self.parent._process_kwargs(kwargs)
         kwargs["custom_device_id"] = processed.device_id
 
         amount_yielded = 0
@@ -594,14 +597,14 @@ class User(Base):
                 "language": processed.language,
             }
             path = "api/favorite/item_list/?{}&{}".format(
-                User.parent._add_url_params(), urlencode(query)
+                self.parent._add_url_params(), urlencode(query)
             )
 
             res = self.parent.get_data(path, **kwargs)
 
             if "itemList" not in res.keys():
                 if first:
-                    User.parent.logger.error("User's likes are most likely private")
+                    self.parent.logger.error("User's likes are most likely private")
                 return
 
             videos = res.get("itemList", [])
@@ -611,7 +614,7 @@ class User(Base):
                 yield self.parent.video(data=video)
 
             if not res.get("hasMore", False) and not first:
-                User.parent.logger.info(
+                self.parent.logger.info(
                     "TikTok isn't sending more TikToks beyond this point."
                 )
                 return
@@ -646,7 +649,7 @@ class User(Base):
             )
 
         if None in (self.username, self.user_id, self.sec_uid):
-            User.parent.logger.error(
+            self.parent.logger.error(
                 f"Failed to create User with data: {data}\nwhich has keys {data.keys()}"
             )
 
@@ -658,7 +661,7 @@ class User(Base):
     def __find_attributes(self) -> None:
         # It is more efficient to check search first, since self.user_object() makes HTML request.
         found = False
-        for u in self.parent.search.users(self.username):
+        for u in self.parent.search(self.username).users():
             if u.username == self.username:
                 found = True
                 self.__update_id_sec_uid_username(u.user_id, u.sec_uid, u.username)

--- a/pytok/api/video.py
+++ b/pytok/api/video.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import logging
 import json
 from urllib import parse as url_parsers
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, Optional
 
 import brotli
 import httpx
@@ -44,7 +44,8 @@ class Video(Base):
     ```
     """
 
-    parent: ClassVar[PyTok]
+    parent: PyTok
+    """The PyTok instance this object is bound to (set by api.video(...))."""
 
     id: Optional[str]
     """TikTok's ID of the Video"""
@@ -67,10 +68,12 @@ class Video(Base):
             username: Optional[str] = None,
             url: Optional[str] = None,
             data: Optional[dict] = None,
+            parent: Optional["PyTok"] = None,
     ):
         """
         You must provide the id or a valid url, else this will fail.
         """
+        self.parent = parent
         self.id = id
         self.username = username
         if data is not None:
@@ -878,7 +881,7 @@ class Video(Base):
             ]
 
         if self.id is None:
-            Video.parent.logger.error(
+            self.parent.logger.error(
                 f"Failed to create Video with data: {data}\nwhich has keys {data.keys()}"
             )
 

--- a/pytok/tiktok.py
+++ b/pytok/tiktok.py
@@ -36,12 +36,6 @@ DESKTOP_BASE_URL = "https://www.tiktok.com/"
 
 class PyTok:
     _is_context_manager = False
-    user = User
-    search = Search
-    sound = Sound
-    hashtag = Hashtag
-    video = Video
-    trending = Trending
     logger = logging.getLogger(LOGGER_NAME)
 
     # Default browser args for stealth
@@ -146,13 +140,16 @@ class PyTok:
 
         * startup_lock: An asyncio.Lock shared across PyTok instances that launch
             browsers concurrently (e.g. a WorkerPool's workers). Held only around
-            the browser-launch phase (zendriver start + session bind), which is
-            NOT safe to run concurrently: zendriver's free_port() is TOCTOU and
-            two Chromes starting at the same instant intermittently leave one
-            session half-built ("No sessions created"). Serializing that phase
-            makes startup deterministic; it is released before account
-            verification so a slow login/captcha on one worker doesn't block the
-            others' startup. None (default) = no serialization (standalone use).
+            the browser-launch phase (zendriver start + session bind), where
+            zendriver's free_port() is TOCTOU: two Chromes starting at the same
+            instant can pick the same debug port. Serializing that phase makes
+            startup deterministic; it is released before account verification so
+            a slow login/captcha on one worker doesn't block the others'
+            startup. None (default) = no serialization (standalone use).
+            (Historical note: most concurrent-startup failures — e.g. "No
+            sessions created" — were actually caused by API classes sharing a
+            class-level `parent`, so every new PyTok hijacked all workers'
+            objects; parent is now bound per instance via the api factories.)
         """
         # assert headless is False, "Running in headless currently does not work reliably."
 
@@ -194,14 +191,6 @@ class PyTok:
 
         self.logger.setLevel(logging_level)
 
-        # Add classes from the api folder
-        User.parent = self
-        Search.parent = self
-        Sound.parent = self
-        Hashtag.parent = self
-        Video.parent = self
-        Trending.parent = self
-
         self.request_cache = {}
 
         # Create zendriver-based TikTokApi instance for API requests
@@ -209,6 +198,42 @@ class PyTok:
             logging_level=logging_level
         )
 
+    # ------------------------------------------------------------------
+    # API object factories
+    #
+    # Each factory binds the created object to THIS PyTok instance via an
+    # instance-level `parent`. These used to be class aliases (`user = User`)
+    # with `User.parent` stamped globally in __init__ — which meant every
+    # PyTok constructed in the process hijacked `parent` for all existing
+    # API objects. With N concurrent workers, worker A's objects would route
+    # requests to worker B's (possibly half-built) browser, causing races
+    # like "No sessions created" at startup. Instance binding removes that
+    # shared state entirely.
+    # ------------------------------------------------------------------
+
+    def user(self, *args, **kwargs) -> User:
+        """Create a User bound to this PyTok instance."""
+        return User(*args, parent=self, **kwargs)
+
+    def search(self, *args, **kwargs) -> Search:
+        """Create a Search bound to this PyTok instance."""
+        return Search(*args, parent=self, **kwargs)
+
+    def sound(self, *args, **kwargs) -> Sound:
+        """Create a Sound bound to this PyTok instance."""
+        return Sound(*args, parent=self, **kwargs)
+
+    def hashtag(self, *args, **kwargs) -> Hashtag:
+        """Create a Hashtag bound to this PyTok instance."""
+        return Hashtag(*args, parent=self, **kwargs)
+
+    def video(self, *args, **kwargs) -> Video:
+        """Create a Video bound to this PyTok instance."""
+        return Video(*args, parent=self, **kwargs)
+
+    def trending(self, *args, **kwargs) -> Trending:
+        """Create a Trending bound to this PyTok instance."""
+        return Trending(*args, parent=self, **kwargs)
 
     # URL patterns we care about - TikTok API and video media
     _TRACKED_URL_PATTERNS = [


### PR DESCRIPTION
## Problem

Launching a WorkerPool with 3 workers / 3 logged-in accounts intermittently failed at startup ("No sessions created", cross-worker session confusion), even after browser launches were serialized by the shared startup lock (fd3aaef) and staggered (70aa78f).

## Root cause

`PyTok.__init__` stamped `User.parent = self` (and likewise for `Video`, `Hashtag`, `Sound`, `Search`, `Trending`) as **class-level** attributes. Every PyTok constructed in the process re-pointed `parent` for **all existing API objects**. With concurrent workers, worker A's `api.user(...)` routed its page navigation and API requests to worker B's newest — possibly half-built — browser. The hijack happens at `PyTok(...)` construction time, which is outside the startup lock, so serializing launches could never fix it.

## Fix

- `api.user()` / `.video()` / `.search()` / `.sound()` / `.hashtag()` / `.trending()` are now real factory methods that pass `parent=self`.
- Each API class stores `parent` as an instance attribute, assigned before data extraction so nested objects (`video.author`, `video.sound`, `video.hashtags`, `sound.author`) inherit the correct instance.
- All remaining class-level `parent` reads (`User.parent...`, `Video.parent.logger`, etc.) converted to `self.parent`.
- The shared startup lock stays: zendriver's `free_port()` is still TOCTOU across concurrent launches. Stale comments describing the race as unexplained are updated.

No caller changes needed — all existing `api.user(...)`-style call sites work unchanged.

## Verification

- Deterministic smoke test: objects created by PyTok `a` keep `parent is a` after PyTok `b` and `c` are constructed; nested author/sound/hashtag objects bind to the right instance; positional-style calls (`api.search('term')`, `api.hashtag('fyp')`) still work.
- Live run with 3 workers / 3 accounts: all three browsers launched and scraped concurrently with no session-setup errors. (A separate slowness issue remains — TikTok API path returning 10201/bot-detection pushes workers onto the scraping fallback, and a single TimeoutException parks a worker in a 5m cooldown when there's no spare account to rotate to. Not addressed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)