### PR TITLE
Fix worker-pool stalls: no cooldown on timeouts, bounded teardown, visible logs

### DIFF
--- a/pytok/accounts/worker.py
+++ b/pytok/accounts/worker.py
@@ -26,7 +26,6 @@ from ..exceptions import (
     NotAvailableException,
     NotFoundException,
     SoundRemovedException,
-    TimeoutException,
 )
 
 logger = logging.getLogger("PyTok")
@@ -46,12 +45,16 @@ DATA_LEVEL_EXCEPTIONS = (
     InvalidJSONException,
     FewerVideosThanExpectedException,
 )
-# Account/session-level & transient: cooldown the current account and rotate,
-# then retry the task on the next available account.
+# Account-level: cooldown the current account and rotate, then retry the task
+# on the next available account. Only genuine account-health signals belong
+# here: with max_workers == number of accounts there is never a spare account,
+# so a rotation costs the full cooldown (the worker waits out its own lock).
+# TimeoutException is deliberately NOT here — a content-visibility timeout is
+# usually a transient page-level failure, handled by the in-place session
+# rebuild in execute_task's generic handler.
 ROTATE_EXCEPTIONS = (
     CaptchaException,
     ApiFailedException,
-    TimeoutException,
 )
 
 # Rotation / rest policy.
@@ -234,15 +237,17 @@ class Worker:
                 await self._close_session()
 
             except Exception as e:
-                # Unknown error / browser crash / transient session failure.
-                # Drop the (probably dead) session and rebuild IN PLACE on the
-                # same account — these recover on a fresh session in seconds.
-                # We deliberately do NOT rotate+cooldown here: with a small pool
-                # (e.g. 2 accounts) rotating just locks this account for minutes
-                # and waits on the other busy one, turning a transient blip into
-                # a multi-minute stall. Genuine rate-limit/captcha/timeout still
-                # rotate via ROTATE_EXCEPTIONS above; a persistently unbuildable
-                # account is caught by _ensure_session's max_build_attempts.
+                # Unknown error / browser crash / transient session failure /
+                # content-visibility timeout. Drop the (probably dead) session
+                # and rebuild IN PLACE on the same account — these recover on a
+                # fresh session in seconds. We deliberately do NOT rotate+
+                # cooldown here: with max_workers == number of accounts there
+                # is never a spare account, so rotating just locks this account
+                # for minutes and waits on the other busy ones, turning a
+                # transient blip into a multi-minute stall. Genuine rate-limit/
+                # captcha signals still rotate via ROTATE_EXCEPTIONS above; a
+                # persistently unbuildable account is caught by
+                # _ensure_session's max_build_attempts.
                 last_exc = e
                 logger.error(f"Worker {self.id}: unexpected error on "
                              f"{self._acct_name()}: {e!r}; rebuilding session in place")
@@ -275,13 +280,40 @@ class Worker:
         if not await self._acquire(wait=True):
             raise NoAccountError(f"Worker {self.id}: no account for rotation")
 
-    async def _close_session(self):
-        if self.api is not None:
-            try:
-                await self.api.shutdown()  # release_on_shutdown=False: keeps account
-            except Exception:
-                pass
-            self.api = None
+    async def _close_session(self, timeout: float = 30.0):
+        """Shut down this worker's PyTok session, bounded so a frozen tab can't
+        hang the worker.
+
+        PyTok.shutdown syncs cookies through the live tab first, and CDP
+        commands have no timeout — if Chrome froze the tab, that await never
+        returns. This hung both mid-run rebuilds and pool teardown. On timeout,
+        escalate: skip the cookie sync and stop the browser directly (also
+        bounded, its close command rides the same connection), then fall back
+        to killing the Chrome process outright.
+        """
+        if self.api is None:
+            return
+        api, self.api = self.api, None
+        try:
+            async with asyncio.timeout(timeout):
+                await api.shutdown()  # release_on_shutdown=False: keeps account
+        except TimeoutError:
+            logger.warning(f"Worker {self.id}: session shutdown timed out after "
+                           f"{timeout:.0f}s; force-stopping browser")
+            browser = getattr(api, "_zendriver_browser", None)
+            if browser is not None:
+                try:
+                    async with asyncio.timeout(15):
+                        await browser.stop()
+                except Exception:
+                    proc = getattr(browser, "_process", None)
+                    if proc is not None:
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+        except Exception:
+            pass
 
     async def _release_current(self):
         if self.current_account:

--- a/pytok/accounts/worker_pool.py
+++ b/pytok/accounts/worker_pool.py
@@ -39,6 +39,7 @@ class WorkerPool:
         tasks_per_rest: Optional[int] = None,
         max_retries: int = 3,
         startup_stagger: float = 0.0,
+        shutdown_grace: float = 30.0,
         **pytok_kwargs,
     ):
         """
@@ -54,14 +55,26 @@ class WorkerPool:
                 0 by default: browser launches are now serialized deterministically
                 by a shared startup lock (see below), so a fixed stagger is no
                 longer needed to keep concurrent Chrome starts from racing.
+            shutdown_grace: seconds close() waits for in-flight worker loops to
+                finish before cancelling them. Idle workers exit within ~1s, so
+                this only matters when close() runs while a task is still going
+                (e.g. an exception or timeout escaped the `async with` body) —
+                without a bound, a worker stuck waiting out an account cooldown
+                would block teardown for minutes.
             **pytok_kwargs: forwarded to each PyTok (headless, request_delay,
-                page_load_timeout, manual_captcha_solves, ...).
+                page_load_timeout, manual_captcha_solves, ...). If logging_level
+                is not given, workers default to this module's "PyTok" logger
+                effective level, so worker-session INFO logs stay visible when
+                the app configured INFO logging (each PyTok sets the shared
+                "PyTok" logger level, so a WARNING default would silence the
+                pool's own progress logs too).
         """
         self.pool = pool
         self.max_workers = max_workers
         self.tasks_per_rest = tasks_per_rest
         self.max_retries = max_retries
         self.startup_stagger = startup_stagger
+        self.shutdown_grace = shutdown_grace
         self.pytok_kwargs = pytok_kwargs
 
         self.workers: List[Worker] = []
@@ -92,6 +105,10 @@ class WorkerPool:
         # launch (first build or mid-run rebuild) runs at a time.
         self._startup_lock = asyncio.Lock()
         self.pytok_kwargs = {**self.pytok_kwargs, "startup_lock": self._startup_lock}
+        # Default worker sessions to the pool logger's verbosity: every PyTok
+        # sets the shared "PyTok" logger's level, so letting workers fall back
+        # to PyTok's WARNING default would silence the pool's own INFO logs.
+        self.pytok_kwargs.setdefault("logging_level", logger.getEffectiveLevel())
 
         for i in range(num):
             try:
@@ -128,6 +145,15 @@ class WorkerPool:
                 result = await worker.execute_task(task)
                 if not future.cancelled():
                     future.set_result(result)
+            except asyncio.CancelledError:
+                # close() cancelled us mid-task (shutdown_grace expired).
+                # Resolve the in-flight future so no caller awaits it forever;
+                # the finally below still marks the queue item done.
+                if not future.done():
+                    future.set_exception(
+                        RuntimeError(f"{worker.id}: pool shut down before task completed")
+                    )
+                raise
             except Exception as e:
                 if not future.cancelled():
                     future.set_exception(e)
@@ -154,7 +180,21 @@ class WorkerPool:
             return
         self._shutdown = True
         if self.worker_tasks:
-            await asyncio.gather(*self.worker_tasks, return_exceptions=True)
+            # Idle loops notice _shutdown within ~1s. A loop still inside
+            # execute_task (e.g. waiting out an account cooldown) gets
+            # shutdown_grace seconds to finish, then is cancelled so teardown
+            # can't hang on a stuck worker.
+            done, pending = await asyncio.wait(
+                self.worker_tasks, timeout=self.shutdown_grace
+            )
+            if pending:
+                logger.warning(
+                    f"WorkerPool.close: cancelling {len(pending)} worker loop(s) "
+                    f"still busy after {self.shutdown_grace:.0f}s grace"
+                )
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*self.worker_tasks, return_exceptions=True)
         for worker in self.workers:
             await worker.close()
         self.workers = []


### PR DESCRIPTION
Follow-up to #22 (stacked on `fix/per-instance-parent` — will retarget to master automatically when #22 merges).

## Problem

Even with the startup race fixed, a 3-worker / 3-account run of a few requests stalled for 25+ minutes and looked like a silent hang. Live diagnosis (watchdog dumps of asyncio task stacks + py-spy) found three compounding stalls:

1. **Timeout → rotate is a guaranteed multi-minute stall when `max_workers == accounts`.** `TimeoutException` was in `ROTATE_EXCEPTIONS`, so a transient content-visibility timeout locked the worker's own account for 5 minutes and tried to rotate — but there is never a spare account, so the worker just waited out its own cooldown. Three task retries ≈ 17 minutes for one failing task.

2. **Teardown could hang forever.** `WorkerPool.close()` waited unboundedly for worker loops (e.g. one stuck in a cooldown wait). Worse, `Worker._close_session` awaited `PyTok.shutdown()`, whose cookie sync runs CDP commands with no timeout — a frozen Chrome tab hung `close()` (observed: 10+ minutes) and could hang mid-run rebuilds the same way.

3. **The stalls were invisible.** Worker PyToks defaulted to `logging_level=WARNING`, and every PyTok sets the level of the shared `"PyTok"` logger — so constructing the first worker silenced the pool's own INFO logs process-wide.

## Fix

- `TimeoutException` moved out of `ROTATE_EXCEPTIONS`; timeouts now rebuild the session in place (fast) like other transient errors. Rotation is reserved for genuine account-health signals (captcha, rate-limit).
- `WorkerPool.close()` gives in-flight worker loops a `shutdown_grace` (new ctor param, default 30s), then cancels them; a cancelled loop resolves its in-flight future so no caller awaits forever. Idle loops still exit within ~1s.
- `Worker._close_session` bounds `PyTok.shutdown()` at 30s, then escalates: direct `browser.stop()` (15s) → raw Chrome process kill. This bounds pool teardown and mid-run rebuilds/rotations alike.
- Worker sessions default `logging_level` to the pool logger's effective level, keeping worker and pool INFO logs visible when the app configured INFO.

## Verification

Live 3-worker / 3-account run: previously hung 25+ minutes with no output; now completes in **2.5 minutes** with full logs — a persistently-failing task fast-fails after 3 in-place rebuilds (~2 min, no cooldowns), worker loops exit within ~1s of shutdown, teardown completes in ~2s.

Note: the tasks in that run still fail on a **separate pre-existing issue** — TikTok returns `statusCode=10201` / bot-detection empty responses on the `item_list` API path and profile pages don't render items for these accounts. Unchanged here; worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)