### PR TITLE
Reuse the browser's real fingerprint params so API-path playAddr URLs download

### DIFF
--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -217,10 +217,11 @@ class User(Base):
             - get_bytes (bool): If True, download each video's MP4 as it is yielded and store
               it on the yielded Video as ``video.video_bytes`` (None if the download failed).
             - prefer_scraping (bool): If True, get videos by scraping the browser page rather
-              than the make_request API. The API returns playAddr URLs whose CDN edge signature
-              the browser cannot authenticate, so they 403 in ``video.bytes()``; scraping yields
-              the browser's own item_list URLs, which download cleanly. Use this when you intend
-              to call ``bytes()`` on the results.
+              than the make_request API. Normally unnecessary: API requests reuse the browser's
+              own fingerprint params (see ZendriverTikTokApi._set_session_params), so their
+              playAddr URLs download cleanly in ``video.bytes()``. Kept as an explicit escape
+              hatch for sessions where no browser param template could be captured (API-path
+              playAddr URLs then 403, as TikTok poisons URLs requested with made-up params).
             - cursor (int): The unix epoch to get uploaded videos since.
 
         Example Usage
@@ -272,8 +273,8 @@ class User(Base):
 
         remaining = None if count is None else count - amount_yielded
         if prefer_scraping:
-            # make_request returns playAddr URLs the browser can't authenticate against the
-            # video CDN (they 403 in bytes()); go straight to scraping for browser-sourced URLs.
+            # Explicit opt-out of the API path: go straight to scraping for
+            # browser-sourced URLs (see the prefer_scraping docstring above).
             async for video in self._get_videos_scraping(remaining):
                 yield video
             return

--- a/pytok/tiktok.py
+++ b/pytok/tiktok.py
@@ -8,6 +8,8 @@ import re
 import time
 from typing import Optional
 
+from urllib.parse import parse_qs, urlparse
+
 import zendriver as zd
 from zendriver import cdp
 import random
@@ -272,17 +274,40 @@ class PyTok:
         self._pending_requests[request_id]['ready'] = True
 
     def _on_request_will_be_sent(self, event: cdp.network.RequestWillBeSent, connection=None):
-        """Capture the first outgoing request's headers from the main tab.
+        """Capture the browser's real request headers and API query params.
 
-        These are the browser's real request headers (user-agent, sec-ch-ua,
+        Headers: taken from the first outgoing request (user-agent, sec-ch-ua,
         accept-language, ...). The API client reuses them for signed fetches and
         the httpx/requests byte-download paths.
+
+        API params: taken from the first API request the webapp's own JS issues.
+        The API client uses them as the base params for its signed fetches so
+        our requests carry the same fingerprint (device_id, odinId,
+        clientABVersions, region, ...) the webapp sends — TikTok poisons the
+        playAddr URLs in item_list responses requested with made-up params
+        (they 403 on download). `clientABVersions` is the discriminator: the
+        webapp always sends it, while PyTok's own in-page fetches never include
+        it until a template has been captured, so we can't capture our own
+        requests here.
         """
         if not isinstance(event, cdp.network.RequestWillBeSent):
             return
         if self._captured_request_headers is None:
             raw = event.request.headers
             self._captured_request_headers = dict(raw) if raw else {}
+        if self._captured_api_params is None:
+            url = event.request.url
+            if (url.startswith('https://www.tiktok.com/api/')
+                    and 'clientABVersions=' in url
+                    and 'device_id=' in url):
+                parsed = urlparse(url)
+                self._captured_api_params = {
+                    k: v[0] for k, v in parse_qs(parsed.query).items()
+                }
+                self.tiktok_api.browser_api_params = self._captured_api_params
+                self.logger.debug(
+                    f"Captured browser API param template from {parsed.path}"
+                )
 
     async def process_pending_responses(self, url_pattern=None):
         """Fetch bodies for ready requests and return those matching the URL pattern."""
@@ -390,10 +415,14 @@ class PyTok:
         self._page.add_handler(cdp.network.ResponseReceived, self._on_response)
         self._page.add_handler(cdp.network.LoadingFinished, self._on_loading_finished)
 
-        # Capture the real request headers off the main tab's first navigation.
-        # The API client reuses these for its signed fetches and for the
-        # httpx/requests byte-download paths (which need a full browser UA).
+        # Capture the real request headers and API query params off the main
+        # tab's traffic (see _on_request_will_be_sent). The API client reuses
+        # them for its signed fetches and the httpx/requests byte-download
+        # paths. Reset both on (re)launch so a rebuilt browser can't serve a
+        # stale template.
         self._captured_request_headers = None
+        self._captured_api_params = None
+        self.tiktok_api.browser_api_params = None
         self._page.add_handler(cdp.network.RequestWillBeSent, self._on_request_will_be_sent)
 
         # Navigate to TikTok (use CDP navigate + wait_for_ready_state to avoid hanging on slow resources)
@@ -409,8 +438,11 @@ class PyTok:
             ) from ex
         await asyncio.sleep(3)
 
-        # Done capturing headers; stop listening so later navigations don't churn.
-        self._page.remove_handlers(cdp.network.RequestWillBeSent)
+        # The handler stays attached: headers are captured off the first
+        # request, but the API param template needs a navigation that fires a
+        # webapp API request, which may only happen later (account
+        # verification, first profile load). Both captures are one-shot, so
+        # the steady-state per-request cost is two None-checks.
 
         # Get user agent from zendriver page
         self._user_agent = await self._page.evaluate("navigator.userAgent")

--- a/pytok/tiktok_api.py
+++ b/pytok/tiktok_api.py
@@ -31,6 +31,9 @@ class TikTokSession:
     ms_token: str = None
     base_url: str = "https://www.tiktok.com"
     is_valid: bool = True
+    # True when params were lifted from a captured browser API request rather
+    # than synthesized; make_request upgrades sessions that predate the capture.
+    params_from_browser: bool = False
 
 
 
@@ -47,6 +50,17 @@ class ZendriverTikTokApi:
         "https://sf16-website-login.neutral.ttwstatic.com/obj/"
         "tiktok_web_login_static/webmssdk/1.0.0.374/webmssdk.js"
     )
+
+    # Per-request / auth query params that must never be lifted from a captured
+    # browser API request into the session's base params — make_request and the
+    # individual API methods supply these per call.
+    _REQUEST_SPECIFIC_PARAMS = frozenset({
+        "msToken", "X-Bogus", "X-Gnarly",
+        "secUid", "uniqueId", "itemID", "aweme_id", "item_id", "comment_id",
+        "cursor", "count", "offset", "coverFormat",
+        "needPinnedItemIds", "post_item_list_request_type",
+        "keyword", "web_search_code", "search_id",
+    })
 
     def __init__(self, logging_level: int = logging.WARN, logger_name: str = None):
         self.sessions = []
@@ -65,6 +79,10 @@ class ZendriverTikTokApi:
         # Cached webmssdk.js source, captured from a healthy session and
         # re-injected to self-heal sessions where the signer failed to load.
         self._signing_sdk_src = None
+        # Query params of a real API request the browser's webapp issued,
+        # captured off the wire by PyTok. When present, they are the base
+        # params for our signed fetches (see _set_session_params for why).
+        self.browser_api_params = None
 
         if logger_name is None:
             logger_name = "ZendriverTikTokApi"
@@ -106,7 +124,28 @@ class ZendriverTikTokApi:
     # ------------------------------------------------------------------
 
     async def _set_session_params(self, session):
-        """Override session params to match what browser actually sends."""
+        """Derive the session's base API params.
+
+        Preferred source: the query params of a real API request the browser's
+        webapp issued (captured off the wire by PyTok). TikTok binds the CDN
+        signature of the playAddr URLs in item_list responses to the requesting
+        fingerprint: item_list fetched with made-up device_id/odinId/etc.
+        returns playAddr URLs that 403 on download (verified empirically —
+        identical request with the browser's own params returns URLs that
+        download fine), and inconsistent params also invite bot detection.
+
+        Fallback (no browser request captured yet): synthesize params from the
+        live tab, randomizing the identifiers we can't read.
+        """
+        if self.browser_api_params:
+            session.params = {
+                k: v for k, v in self.browser_api_params.items()
+                if k not in self._REQUEST_SPECIFIC_PARAMS
+            }
+            session.params_from_browser = True
+            return
+        session.params_from_browser = False
+
         user_agent = await session.tab.evaluate("navigator.userAgent")
         language = await session.tab.evaluate(
             "navigator.language || navigator.userLanguage"
@@ -667,6 +706,12 @@ class ZendriverTikTokApi:
             i, session = await self._get_valid_session_index(**kwargs)
         except Exception:
             i, session = self._get_session(**kwargs)
+
+        # Late-bind the browser param template: the capture needs a navigation
+        # that fires a webapp API request, which may land after this session was
+        # built. Upgrade the session's params on first use after the capture.
+        if self.browser_api_params and not session.params_from_browser:
+            await self._set_session_params(session)
 
         if session.params is not None:
             params = {**session.params, **params}


### PR DESCRIPTION
## Problem

Downloading MP4s when scraping user videos required `prefer_scraping=True`: the `playAddr` URLs in metadata fetched via the `make_request` API path returned **403** on every download method, while the browser-scraped metadata for the same videos downloaded fine.

## Root cause

TikTok binds the CDN signature of the `playAddr` URLs it returns from `item_list` to the requesting fingerprint params. `_set_session_params` sent **randomized** `device_id`, `odinId`, `WebIdLastTime`, screen dims, hardcoded `region=US`, `os=win32`, and omitted `clientABVersions` — so TikTok returned well-formed responses whose signed URLs were poisoned. Confirmed by a live A/B experiment (same account, same videos):

| item_list request params | playAddr download |
|---|---|
| randomized (old behavior) | 403 via direct httpx with full cookies AND via in-page `fetch` with credentials |
| browser's own values | OK (4.2 MB / 21 MB downloads) |

## Fix

- `tiktok.py`: the existing `RequestWillBeSent` handler also captures the query params off the first API request the webapp's own JS issues, and stays attached until that happens (it used to be removed after the initial navigation). `clientABVersions=` is the discriminator: the webapp always sends it, and PyTok's own in-page fetches never contain it before a template exists, so we can never capture our own requests.
- `tiktok_api.py`: `_set_session_params` uses the captured params as the session's base params (minus per-request keys like `msToken`, `secUid`, `cursor`); `make_request` upgrades sessions that were built before the capture landed. The old synthesized params remain as a fallback when no template has been captured.
- `api/user.py`: updated the now-stale `prefer_scraping` docs; the flag is kept as an escape hatch for the no-template case.

## Verification

End-to-end on a fresh session (pool account, `@therock`), pure API path, no `prefer_scraping`:

```
template captured at startup: True
used_api_for_info: True
video 7659858636046355726: DOWNLOAD OK (4231023 bytes)
video 7659612982682324237: DOWNLOAD OK (21365924 bytes)
video 7659403334243093773: DOWNLOAD OK (22494534 bytes)
session params_from_browser: True
RESULT: 3/3 downloads OK
```

The logged-in homepage fires a qualifying webapp API request during startup navigation, so the template is normally in place before the first API call.

Side note: sending consistent fingerprint params may also help the intermittent `statusCode=10201` bot-detection responses seen in multi-worker runs (same inconsistent-fingerprint smell); not yet re-verified under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)