### PR TITLE
Expire cached param templates after a TTL

### DIFF
--- a/pytok/tiktok_api.py
+++ b/pytok/tiktok_api.py
@@ -10,6 +10,7 @@ import dataclasses
 import json
 import logging
 import random
+import time
 from typing import Any, Optional
 from urllib.parse import urlencode, quote, urlparse
 
@@ -60,6 +61,14 @@ class ZendriverTikTokApi:
     _TEMPLATE_EXCLUDED_PARAMS = frozenset({
         "msToken", "X-Bogus", "X-Gnarly", "X-Dynosaur",
     })
+
+    # Templates rot: captured params include moment-bound values (time_of_day,
+    # day_of_week, window state, ...) that TikTok cross-checks. Replaying a
+    # template past this age gets playAddr URLs in the response poisoned (they
+    # 403 on download) even though the JSON response itself still succeeds —
+    # observed live ~25-45 min after capture. Treat an aged template as absent
+    # so the lazy scraping route re-captures a fresh one.
+    TEMPLATE_TTL_SECONDS = 15 * 60
 
     def __init__(self, logging_level: int = logging.WARN, logger_name: str = None):
         self.sessions = []
@@ -151,7 +160,7 @@ class ZendriverTikTokApi:
         """
         key = self._endpoint_key(url)
         is_new = key not in self._api_param_cache
-        self._api_param_cache[key] = dict(params)
+        self._api_param_cache[key] = (dict(params), time.monotonic())
         ms_token = params.get("msToken")
         if ms_token:
             self._latest_ms_token = ms_token
@@ -159,7 +168,20 @@ class ZendriverTikTokApi:
             self.logger.info(f"Captured param template for endpoint '{key}'")
 
     def get_cached_api_params(self, url: str) -> Optional[dict]:
-        return self._api_param_cache.get(self._endpoint_key(url))
+        key = self._endpoint_key(url)
+        entry = self._api_param_cache.get(key)
+        if entry is None:
+            return None
+        params, captured_at = entry
+        if time.monotonic() - captured_at > self.TEMPLATE_TTL_SECONDS:
+            self.logger.info(
+                f"Param template for endpoint '{key}' exceeded its "
+                f"{self.TEMPLATE_TTL_SECONDS}s TTL; treating as absent so the "
+                "scraping route re-captures a fresh one"
+            )
+            del self._api_param_cache[key]
+            return None
+        return params
 
     def is_self_issued(self, url: str) -> bool:
         """True if this request URL is one of our own in-flight fetches.


### PR DESCRIPTION
Lands `1971bf5`, the one commit left on `feat/per-endpoint-param-cache` after #25 merged `44b4f28`. It has been running on the MEO edge-worker laptop this whole time — that checkout sits on this branch rather than master — but it never got onto master, so every other consumer is missing it.

## What it fixes

Captured param templates rot. They include moment-bound values (`time_of_day`, `day_of_week`, window state, …) that TikTok cross-checks, so replaying a template past ~25–45 min gets the playAddr URLs in `item_list` responses poisoned — they 403 on download — **while the JSON responses themselves keep succeeding**. That's the nasty part: the existing empty-response invalidation path never fires, because nothing looks broken until you try to fetch bytes.

Measured on a 3-account pool: ~37 videos/min on fresh templates, decaying to ~100% byte-download failure as sessions aged past ~30 min, while a concurrently-launched fresh session downloaded the same videos fine.

The fix treats a template older than `TEMPLATE_TTL_SECONDS` (15 min) as absent, so the next request for that endpoint raises `NoTemplateException` and the scraping fallback re-captures a fresh template off the wire.

## Why now

`d9d6132` (callable `get_bytes`) makes `user.videos()` download mp4s during a normal user scrape, and dt-tiktok-crawler#15 uses it to backfill missing media. That backfill is exactly the workload this commit protects: a long run ages past the template TTL, and without this every mp4 download 403s while the metadata scrape carries on looking healthy. Merging this is what lets the worker laptop move onto master and pick up both.

## Merge safety

- Master hasn't touched `pytok/tiktok_api.py` since the merge-base, so the merge is textually clean (verified with a test merge — no conflicts).
- The change makes `_api_param_cache` values `(params, captured_at)` tuples instead of bare dicts. That's contained: every external reader (`api/hashtag.py`, `api/search.py`, `api/sound.py`, and `tiktok_api.py:703`) goes through `get_cached_api_params()`, which still returns a plain dict or None. The invalidation path (`_api_param_cache.pop`) and `clear_api_param_cache()` are shape-agnostic.
- `api/sound.py`, which arrived on master after this branch, reads through the same accessor and so is covered too.
- Sanity-checked on the merged tree: a fresh read returns the params dict, and a read of an entry aged past the TTL returns `None` and evicts the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)