### PR TITLE
Say what actually failed when video bytes can't be fetched

### DIFF
--- a/pytok/api/video.py
+++ b/pytok/api/video.py
@@ -5,6 +5,7 @@ import base64
 from datetime import datetime
 import logging
 import json
+import time
 from urllib import parse as url_parsers
 from typing import TYPE_CHECKING, Optional
 
@@ -366,17 +367,18 @@ class Video(Base):
             output.write(video_bytes)
         ```
         """
-        # playAddr is the highest-bitrate variant; prefer it for quality, fall back to download.
+        # playAddr is the highest-bitrate variant; prefer it for quality, fall back to
+        # download. Carry the variant name so a failure can say which URL was tried.
         bytes_urls = [
-            self.as_dict['video'].get('playAddr'),
-            self.as_dict['video'].get('downloadAddr'),
+            ("playAddr", self.as_dict['video'].get('playAddr')),
+            ("downloadAddr", self.as_dict['video'].get('downloadAddr')),
         ]
-        bytes_urls = [url for url in bytes_urls if url]
+        bytes_urls = [(name, url) for name, url in bytes_urls if url]
         if not bytes_urls:
             raise exceptions.NotAvailableException("Post does not have a video")
 
         # If the bytes were already captured on the wire (e.g. during playback), use them.
-        paths = [url_parsers.urlparse(url).path for url in bytes_urls]
+        paths = [url_parsers.urlparse(url).path for _, url in bytes_urls]
         cached = self._find_cached_bytes(paths)
         if cached is not None and self._looks_like_video(cached):
             return cached
@@ -392,16 +394,56 @@ class Video(Base):
         req_exceptions = []
         for fetcher_name, fetcher in (("httpx", self._httpx_fetch_bytes),
                                       ("browser", self._browser_fetch_bytes)):
-            for bytes_url in bytes_urls:
+            for url_name, bytes_url in bytes_urls:
+                label = f"{fetcher_name}/{url_name}"
+                started = time.monotonic()
                 try:
                     data = await asyncio.wait_for(fetcher(bytes_url), timeout=timeout)
+                except asyncio.TimeoutError:
+                    # asyncio.TimeoutError stringifies to '', which is what used to make
+                    # this whole list read as ['httpx: ', 'browser: ', ...] -- saying
+                    # nothing about what went wrong. Name it outright. Landing here rather
+                    # than on httpx's own ReadTimeout is a signal in itself: it points at
+                    # the CDP round trip (cookie read, in-page eval), which has no timeout
+                    # of its own, rather than at the CDN download.
+                    req_exceptions.append(f"{label}: timed out after {timeout}s")
                 except Exception as ex:
-                    req_exceptions.append(f"{fetcher_name}: {ex}")
-                    continue
-                if self._looks_like_video(data):
-                    return data
-                req_exceptions.append(f"{fetcher_name}: {bytes_url[:60]}... did not return an MP4")
-        raise Exception(f"Failed to get video bytes, exceptions: {req_exceptions}")
+                    # never interpolate a bare exception -- plenty of them stringify to ''
+                    if not str(ex):
+                        detail = type(ex).__name__
+                    elif type(ex) is Exception:
+                        detail = str(ex)  # raised here with a written-out message already
+                    else:
+                        detail = f"{type(ex).__name__}: {ex}"
+                    req_exceptions.append(
+                        f"{label}: {detail} (after {time.monotonic() - started:.1f}s)"
+                    )
+                else:
+                    if self._looks_like_video(data):
+                        return data
+                    req_exceptions.append(f"{label}: {self._describe_body(data)}")
+        raise Exception(
+            f"Failed to get video bytes for video {self.id}: " + "; ".join(req_exceptions)
+        )
+
+    @staticmethod
+    def _describe_body(body) -> str:
+        """Say what a response that wasn't an MP4 actually was.
+
+        The old message only echoed the URL back, so a CDN error page, an empty body and a
+        DASH fragment were indistinguishable -- all three read as "did not return an MP4".
+        """
+        if body is None:
+            return "returned no data"
+        if not isinstance(body, (bytes, bytearray)):
+            return f"returned {type(body).__name__}, not bytes"
+        if not body:
+            return "returned 0 bytes"
+        head = bytes(body[:12])
+        if head.lstrip()[:1] in (b'<', b'{'):
+            # an HTML/JSON error page served with a 200
+            return f"returned {len(body)} bytes of markup/JSON, not an MP4 ({head!r})"
+        return f"returned {len(body)} bytes but no ftyp box, not a progressive MP4 ({head!r})"
 
     def _find_cached_bytes(self, paths) -> Optional[bytes]:
         """Return video bytes from the CDP response cache if present, else None."""


### PR DESCRIPTION
Diagnostics only — no change to what succeeds or fails.

## The problem

The overnight mp4 backfill logged this 94 times:

```
get_bytes: failed to download bytes for video 7663271651286535454: Failed to get video bytes, exceptions: ['httpx: ', 'httpx: ', 'browser: ', 'browser: ']
```

Every entry is `f"{fetcher_name}: {ex}"`, and everything after the colon is empty. The reason:

```python
>>> str(asyncio.TimeoutError())
''
```

`asyncio.wait_for` raises `asyncio.TimeoutError` (in 3.11+ literally `TimeoutError`), which stringifies to nothing. So the single most useful fact — that all four attempts *timed out* — was exactly what the message threw away. Every explicit `raise` in both fetchers has a real message, which is why the empty ones could only have been the timeout.

The arithmetic confirms it: `timeout=60`, 2 fetchers × 2 URL variants = 4 attempts = **240s**, matching the 4-minute cadence between those log lines to the second (21:33:47 → 21:37:47 → 21:41:47 → 21:45:48 → 21:49:48).

## The change

- catch `asyncio.TimeoutError` separately and say `timed out after 60s`
- for anything else, lead with the exception type, so an empty `str()` can never blank the message again
- label each attempt with its URL variant (`httpx/playAddr`, `browser/downloadAddr`) — previously you couldn't tell which of the two URLs was tried
- report elapsed time per attempt, so "hung" and "rejected instantly" are distinguishable
- a non-MP4 response now says what it *was* — markup/JSON, empty, or bytes without an `ftyp` box — instead of echoing the URL back, so a CDN error page served with a 200 is visible
- name the video id in the final exception

Before / after for the failure that actually happened:

```
- Failed to get video bytes, exceptions: ['httpx: ', 'httpx: ', 'browser: ', 'browser: ']
+ Failed to get video bytes for video 7663271651286535454: httpx/playAddr: timed out after 60s;
+ httpx/downloadAddr: timed out after 60s; browser/playAddr: timed out after 60s;
+ browser/downloadAddr: timed out after 60s
```

## What the new message will tell us next time

Landing on `timed out` rather than httpx's own `ReadTimeout` is itself a signal. `_httpx_fetch_bytes` sets `httpx.AsyncClient(timeout=60)`, equal to the outer `wait_for` — so a slow *download* should surface as a named `ReadTimeout` first. Hitting the outer timeout instead points upstream of the request, at the CDP round trip (`cdp.network.get_cookies`, the in-page `_evaluate`), which has no timeout of its own. That is also the most likely culprit for the backfill wedging solid afterwards, since a CDP await outside any `wait_for` blocks forever. Worth a follow-up; deliberately not in this PR.

## Testing

No test suite here, so I drove `Video.bytes()` with both fetchers stubbed, asserting on the message for each failure mode: all-four-timeout (the real case), an exception with an empty `str()`, a CDN 403, markup vs empty body, `None`, and the three success paths (httpx wins / falls back to browser / playAddr-only). Also checked no entry can render as a bare `label: `.

🤖 Generated with [Claude Code](https://claude.com/claude-code)