### PR TITLE
Raise a distinct exception for posts that have no video

### DIFF
--- a/pytok/api/video.py
+++ b/pytok/api/video.py
@@ -375,7 +375,11 @@ class Video(Base):
         ]
         bytes_urls = [(name, url) for name, url in bytes_urls if url]
         if not bytes_urls:
-            raise exceptions.NotAvailableException("Post does not have a video")
+            # a photo/slideshow post rather than anything wrong: raise the specific exception
+            # so a media collector can skip it without treating it as a failed download.
+            raise exceptions.NoVideoException(
+                f"Post {self.id} has no video to download (photo/slideshow post)"
+            )
 
         # If the bytes were already captured on the wire (e.g. during playback), use them.
         paths = [url_parsers.urlparse(url).path for _, url in bytes_urls]

--- a/pytok/exceptions.py
+++ b/pytok/exceptions.py
@@ -39,6 +39,17 @@ class InvalidJSONException(TikTokException):
 class NotAvailableException(TikTokException):
     """The requested object is not available in this region."""
 
+class NoVideoException(NotAvailableException):
+    """This post has no video to download — it is a photo/slideshow post.
+
+    A property of the post, not of the session or the account, so a caller collecting media
+    should skip it and carry on rather than counting it as a download failure. Photo-heavy
+    profiles post these in long runs, which would otherwise look like a broken session.
+
+    Subclasses NotAvailableException so callers that only catch that keep working. A caller
+    which maps NotAvailableException to "this account is unavailable, skip the handle" has to
+    catch this one *first*: one photo post says nothing about the account."""
+
 class NoContentException(TikTokException):
     """TikTok returned no content"""
 


### PR DESCRIPTION
`video.bytes()` raised `NotAvailableException` for a photo/slideshow post — the same exception the TikTok crawler's handle-level classifier maps to *"this account is not available, skip the handle"*. One photo post says nothing about the account.

A media collector wants to skip such a post and carry on, rather than count it as a failed download: photo-heavy profiles post them in long runs, so conflating the two makes a healthy session look broken. In the 2026-08-03 mp4 backfill, **85 of 94 logged "byte download failures" were photo posts**.

`NoVideoException` subclasses `NotAvailableException`, so callers that only catch that keep working unchanged (`meo-incidents/scripts/download_videos.py` relies on it) while new code can be precise. The docstring flags the ordering trap: anything mapping `NotAvailableException` to "skip the handle" must catch `NoVideoException` first.

## Test

- raises `NoVideoException`, still an instance of `NotAvailableException` and `TikTokException`
- a bare `except NotAvailableException` still catches it
- a post that *does* have a `playAddr` still takes the normal fetch path and is never reported as a photo post

🤖 Generated with [Claude Code](https://claude.com/claude-code)