### PR TITLE
Don't pass off a blocked video listing as an empty account

### DIFF
--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -260,9 +260,41 @@ class User(Base):
             yield video
 
     async def _iter_videos(self, count=None, batch_size=100, prefer_scraping=False, **kwargs) -> Iterator[Video]:
-        if self.as_dict and self.as_dict.get('videoCount', 1) == 0:
+        """Yield this user's videos, refusing to pass off a blocked listing as an empty one.
+
+        Every route in here (initial page harvest, API, scraping) falls back to the next on
+        failure, and the last one just stops if it finds nothing -- so a session TikTok is
+        bot-blocking produced an empty iterator that a caller could not tell apart from an
+        account with no videos. That silence is expensive downstream: the TikTok crawler
+        recorded such handles as successfully collected and wrote PHH crawler history for the
+        range, telling the gap report never to ask again.
+
+        The profile's own videoCount is the discriminator, and it is what makes this safe to
+        check here rather than in the caller: it compares against what this iterator *yielded*,
+        not what the caller kept, so a caller filtering everything out (a date window, say) is
+        not mistaken for a failure. Raised as ApiFailedException because a block is
+        session-level -- the accounts WorkerPool rotates and retries on a fresh session.
+        """
+        # None when info() was never called: no expectation to check against, so the guard
+        # below stays off rather than guessing.
+        expected_videos = self.as_dict.get('videoCount') if self.as_dict else None
+        if expected_videos == 0:
             return
 
+        amount_yielded = 0
+        async for video in self._iter_videos_inner(count=count, batch_size=batch_size,
+                                                  prefer_scraping=prefer_scraping, **kwargs):
+            amount_yielded += 1
+            yield video
+
+        if amount_yielded == 0 and expected_videos:
+            raise ApiFailedException(
+                f"no videos returned for @{self.username} though the profile reports "
+                f"{expected_videos} -- the listing failed rather than being empty "
+                f"(TikTok commonly answers a blocked session with an empty response)"
+            )
+
+    async def _iter_videos_inner(self, count=None, batch_size=100, prefer_scraping=False, **kwargs) -> Iterator[Video]:
         # If user info was obtained via TikTok-Api, use API for videos directly
         # If user info was scraped (page already loaded), get initial videos from page first
         amount_yielded = 0


### PR DESCRIPTION
## The bug

Every route in `_iter_videos` falls back to the next on failure — initial page harvest → API → scraping — and the last one just *stops* if it finds nothing. So a session TikTok is bot-blocking produces an empty iterator that a caller cannot tell apart from an account with no videos.

In the 2026-08-04 media backfill, **8 of 27 handles came back `0 videos`**, and every single one was immediately preceded by:

```
Getting handle theandrewschulz
make_request failed: ('', "TikTok returned an empty response. They are detecting you're a bot, consider using a proxy")
API method failed... Falling back to scraping method.
theandrewschulz: 0 videos, mp4s: 0 downloaded, 0 already in S3, 0 photo posts, 0 failed
```

`theandrewschulz` reports **`videoCount=253`** and downloads fine on a healthy session.

## Why it matters beyond the missing videos

Reported as success, the TikTok crawler writes PHH crawler history claiming the range was collected — which tells the gap report never to ask for that seed again. With `all_time=True` it reaches the `start_date = '2015-01-01'` branch and claims *all of TikTok history* as covered for that seed. Silent, permanent data loss.

## The fix

The profile's own `videoCount` is the discriminator, and checking it inside `_iter_videos` rather than in the caller is what makes it safe: it compares against what the **iterator yielded**, not what the caller kept. So a caller filtering everything out — a date window, say — is not mistaken for a failure, and a caller that breaks early has already received a video so it cannot trip the guard either. When `info()` was never called there is no expectation to check against and the guard stays off rather than guessing.

Raised as `ApiFailedException`, which is in the WorkerPool's `ROTATE_EXCEPTIONS`: a block is session-level, so cooldown + rotate + retry on a fresh session is the right response. `FewerVideosThanExpectedException` would be the obvious name but sits in `DATA_LEVEL_EXCEPTIONS`, which propagates with no retry at all.

The existing body is renamed `_iter_videos_inner` and left otherwise untouched; the `videoCount == 0` early return moves up to the wrapper.

## Test

- `videoCount=253`, 0 yielded → `ApiFailedException`
- `videoCount=0`, 0 yielded → returns empty, no raise (genuinely empty profile)
- `videoCount=253`, 3 yielded → no raise
- no `videoCount` (info() never called) → guard disabled, no raise
- `videoCount=253`, **caller breaks after 1** → no raise
- `videoCount=9999`, 1 yielded → no raise (one video proves the listing worked)
- asserts `ApiFailedException` is in `ROTATE_EXCEPTIONS` and not `DATA_LEVEL_EXCEPTIONS`

Live, real Chrome and real TikTok: `theandrewschulz` collects 4 videos and downloads 4 mp4s with the guard silent — no false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)