### PR TITLE
Stop a late CDP response from killing the connection listener

### DIFF
--- a/pytok/_cdp_patches.py
+++ b/pytok/_cdp_patches.py
@@ -1,4 +1,9 @@
-"""Runtime patches for zendriver's auto-generated CDP bindings.
+"""Runtime patches for zendriver.
+
+Two unrelated fragilities, both of which cost us whole scraping sessions:
+``apply_cdp_patches`` fixes ``ClientSecurityState`` parsing (below) and guards CDP
+response dispatch so a late reply can't kill the connection's listener task (see
+``_patch_transaction_dispatch``).
 
 zendriver (like its upstream, nodriver) generates its CDP dataclasses from the
 Chrome DevTools Protocol spec, so its ``ClientSecurityState`` tracks whichever
@@ -37,7 +42,73 @@ _POLICY_SPELLINGS = (
 )
 
 
+def _patch_transaction_dispatch() -> None:
+    """Stop a late CDP response from killing the connection's listener task. Idempotent.
+
+    ``Transaction`` is an ``asyncio.Future`` and ``Transaction.__call__`` resolves it with
+    ``set_result`` unconditionally. ``asyncio.wait_for`` *cancels* that future when it times
+    out, so a reply that arrives after the caller gave up lands on an already-cancelled
+    future and ``set_result`` raises ``InvalidStateError``. That propagates out of the bare
+    ``tx(**message)`` in ``Listener.listener_loop`` — the command-response branch has no
+    exception handling, unlike the event branch below it — so the listener task dies. After
+    that no CDP reply is ever delivered again and every later ``page.send()`` waits forever
+    on a future nothing will resolve: the session is wedged permanently, and because
+    ``send()`` has no timeout of its own, only the caller's own timeout bounds it.
+
+    That is how one timed-out ``Network.getCookies`` took out a whole scraping session on
+    2026-08-04 (16 ``InvalidStateError``s; both pool workers stuck holding their accounts,
+    the run silent for ~50 minutes). Tightening a caller-side timeout makes it *more* likely,
+    since abandoning a transaction is what creates the race.
+
+    Guarding ``__call__`` rather than ``listener_loop`` keeps this small and version-robust:
+    we delegate to the original for everything we don't need to change, instead of
+    reimplementing the loop body. Neither zendriver 0.15.5 (the newest release) nor upstream
+    ``main`` guards this, so there is no version to upgrade to.
+    """
+    from zendriver.core.connection import Transaction
+
+    if getattr(Transaction, "_pytok_dispatch_guarded", False):
+        return
+
+    original_call = Transaction.__call__
+
+    def __call__(self, **response):  # noqa: N807 - patching a dunder on someone else's class
+        if self.done():
+            # Caller already gave up (wait_for cancelled us), or we were resolved once
+            # already. Delivering now is a no-op, not a reason to bring the listener down.
+            logger.debug(
+                "Dropping CDP response for settled transaction %s",
+                getattr(self, "method", "?"),
+            )
+            return None
+        try:
+            return original_call(self, **response)
+        except Exception as ex:
+            # Anything else the original raises (e.g. ProtocolException for a response it
+            # cannot parse) also reaches the listener as a fatal error. Fail just this
+            # transaction instead: whoever is awaiting it gets a real exception rather than
+            # hanging, and the connection stays usable for every other transaction.
+            logger.warning(
+                "CDP response dispatch failed for %s: %r",
+                getattr(self, "method", "?"),
+                ex,
+            )
+            if not self.done():
+                self.set_exception(ex)
+            return None
+
+    Transaction.__call__ = __call__
+    Transaction._pytok_dispatch_guarded = True
+    logger.debug("Applied CDP transaction dispatch guard to zendriver")
+
+
 def apply_cdp_patches() -> None:
+    """Apply every zendriver runtime patch. Idempotent."""
+    _patch_transaction_dispatch()
+    _apply_client_security_state_patch()
+
+
+def _apply_client_security_state_patch() -> None:
     """Make ClientSecurityState parse across Chrome/zendriver versions. Idempotent."""
     from zendriver.cdp import network
 


### PR DESCRIPTION
## No version to upgrade to

Checked first: installed **0.15.5 is the newest release on PyPI**, and upstream `main` in *both* repos (`cdpdriver/zendriver` and `stephanlensky/zendriver`) still has the unguarded `set_result`. So this has to be patched locally.

## The bug

`Transaction` is an `asyncio.Future`, and `Transaction.__call__` resolves it unconditionally:

```python
try:
    self.__cdp_obj__.send(response["result"])
except StopIteration as e:
    return self.set_result(e.value)   # <-- no guard on self.done()
```

`asyncio.wait_for` **cancels** that future when it times out. A reply arriving after the caller gave up therefore lands on an already-cancelled future and `set_result` raises `InvalidStateError`. That escapes the bare `tx(**message)` in `Listener.listener_loop` — the command-response branch has no exception handling, unlike the event branch immediately below it — so **the listener task dies**. After that no CDP reply is ever delivered again, and every later `page.send()` waits forever on a future nothing will resolve. `send()` has no timeout of its own, so only the caller's own timeout bounds it.

Straight from the media backfill log:

```
File "zendriver/core/connection.py", line 123, in __call__
    self.__cdp_obj__.send(response["result"])
StopIteration: [Cookie(name='sid_guard', ...)]

During handling of the above exception, another exception occurred:

File "zendriver/core/connection.py", line 780, in listener_loop
    tx(**message)
asyncio.exceptions.InvalidStateError: invalid state
```

One timed-out `Network.getCookies` took out a whole scraping session on 2026-08-04: **16 `InvalidStateError`s**, both accounts-pool workers stuck holding their accounts, the run silent for ~50 minutes with the process idle. Note that tightening a caller-side timeout makes this *more* likely, since abandoning a transaction is what creates the race — worth knowing before anyone lowers another timeout.

## The fix

Guard `__call__`:

- **already settled** → drop the response. The caller gave up or we resolved once already; delivering now is a no-op, not a reason to bring the listener down.
- **any other dispatch failure** (e.g. `ProtocolException` on an unparseable reply) → `set_exception` on that one transaction, so whoever awaits it gets a real error instead of hanging and the connection stays usable for everything else.

Patching `__call__` rather than `listener_loop` keeps it small and version-robust — we delegate to the original instead of reimplementing the loop body, which would have to be re-verified against every zendriver bump. `EventTransaction` subclasses `Transaction` without overriding `__call__`, so both are covered. Lives alongside the existing `ClientSecurityState` patch in `_cdp_patches.py` and is idempotent like it.

## Test

Reproduces the production failure at the `Transaction` level using a real CDP generator and a real cookie reply:

```
late reply to an abandoned transaction:
  unpatched  listener would DIE: InvalidStateError: invalid state
  patched    listener survives the late reply

normal dispatch still resolves the future: got cookie 'sid_guard'
unparseable reply -> only that transaction fails: KeyError
applying the patch twice is a no-op
```

Plus live against real Chrome and real TikTok with the patch active: `canada76_canada` → `12 videos, mp4s: 8 downloaded, 0 already in S3, 4 photo posts, 0 failed`, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)