### PR TITLE
Bound every CDP command instead of one call site at a time

### DIFF
--- a/pytok/_cdp_patches.py
+++ b/pytok/_cdp_patches.py
@@ -30,10 +30,50 @@ zendriver and nodriver share the underlying fragility, so swapping libraries doe
 not help.
 """
 
+import asyncio
 import dataclasses
 import logging
+import os
+
+from .exceptions import CDPTimeoutException
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on how long a single CDP command may wait for its reply. Any real command
+# answers in milliseconds; the slowest legitimate one is the in-page base64 video fetch,
+# whose caller already caps it well below this. So this is not a performance knob — it exists
+# purely so a command that will *never* be answered cannot hang its coroutine forever.
+DEFAULT_CDP_TIMEOUT = 120.0
+
+
+def _cdp_timeout():
+    """Seconds to allow one CDP command, or None to disable the bound entirely."""
+    raw = os.environ.get("PYTOK_CDP_TIMEOUT")
+    if raw is None:
+        return DEFAULT_CDP_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring PYTOK_CDP_TIMEOUT=%r (not a number); using %gs", raw,
+            DEFAULT_CDP_TIMEOUT,
+        )
+        return DEFAULT_CDP_TIMEOUT
+    # <= 0 is the escape hatch for debugging a command that legitimately takes forever
+    return value if value > 0 else None
+
+
+def _cdp_command_name(cdp_obj) -> str:
+    """Name the command without touching the generator.
+
+    Transaction.__init__ gets the real method name via ``next(cdp_obj)``, which *consumes*
+    the first yield — doing that here would corrupt the command before it is sent. The
+    generator's code name ("get_cookies", "evaluate") is close enough for an error message.
+    """
+    try:
+        return cdp_obj.gi_code.co_qualname
+    except AttributeError:
+        return getattr(getattr(cdp_obj, "gi_code", None), "co_name", "?")
 
 # (dataclass field name, JSON key) for each spelling of the policy, newest first.
 _POLICY_SPELLINGS = (
@@ -102,9 +142,70 @@ def _patch_transaction_dispatch() -> None:
     logger.debug("Applied CDP transaction dispatch guard to zendriver")
 
 
+def _patch_connection_send_timeout() -> None:
+    """Bound every CDP command so an unanswered one can't hang forever. Idempotent.
+
+    ``Connection.send`` ends in ``return await tx`` on a bare Future. Nothing resolves that
+    future except a reply from the browser, and nothing bounds the wait — so any page that
+    stops servicing the DevTools protocol hangs its caller permanently, and each caller has
+    to remember to impose its own timeout.
+
+    Relying on callers is what kept biting us. ``video.bytes()`` grew a timeout, which fixed
+    the byte fetch and moved the hang to the listing walk instead: on 2026-08-05 the media
+    backfill lost all three pool workers one at a time over two hours to CDP calls elsewhere
+    in pytok, ending with an alive-but-idle event loop, every thread-pool thread idle, and no
+    error of any kind in the log. Bounding it here covers every call site at once, including
+    the ones nobody has thought about yet.
+
+    On timeout we raise ``CDPTimeoutException`` rather than letting ``asyncio.TimeoutError``
+    out: the bare one stringifies to ``''`` (which has already cost us one debugging session),
+    and the named one lands in ``Worker.execute_task``'s generic handler, which rebuilds the
+    session in place — the right recovery for a dead browser.
+
+    Depends on the transaction dispatch guard above. ``wait_for`` *cancels* the transaction on
+    timeout, so a late reply would otherwise hit a cancelled future, raise
+    ``InvalidStateError`` inside the listener and kill it — turning one bounded hang into a
+    permanently dead connection. Bounding ``send`` without that guard would be worse than not
+    bounding it at all, which is why ``apply_cdp_patches`` installs them in this order.
+    """
+    from zendriver.core.connection import Connection
+
+    # marker on the function, not the class: Connection's CantTouchThis metaclass refuses
+    # attribute assignment outright, so there is nowhere on the class to record this.
+    if getattr(Connection.send, "_pytok_bounded", False):
+        return
+
+    original_send = Connection.send
+
+    async def send(self, cdp_obj, _is_update: bool = False):
+        timeout = _cdp_timeout()
+        if timeout is None:
+            return await original_send(self, cdp_obj, _is_update)
+        try:
+            return await asyncio.wait_for(
+                original_send(self, cdp_obj, _is_update), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            raise CDPTimeoutException(
+                f"CDP command {_cdp_command_name(cdp_obj)} was not answered within "
+                f"{timeout:g}s — the page has stopped servicing DevTools, so this session "
+                f"needs rebuilding"
+            ) from None
+
+    send._pytok_bounded = True
+    # Connection's metaclass (CantTouchThis) rejects every class-level assignment, to stop
+    # callers creating shared mutable class state like `websocket`. Replacing a method is not
+    # that, so go under it via type.__setattr__ rather than leaving the hang unfixed.
+    type.__setattr__(Connection, "send", send)
+    logger.debug("Bounded zendriver CDP commands at %s", _cdp_timeout())
+
+
 def apply_cdp_patches() -> None:
     """Apply every zendriver runtime patch. Idempotent."""
+    # order matters: the dispatch guard has to be in place before send() starts cancelling
+    # transactions on timeout, or a late reply to a cancelled one kills the listener.
     _patch_transaction_dispatch()
+    _patch_connection_send_timeout()
     _apply_client_security_state_patch()
 
 

--- a/pytok/exceptions.py
+++ b/pytok/exceptions.py
@@ -56,6 +56,19 @@ class NoContentException(TikTokException):
 class TimeoutException(TikTokException):
     """Timed out trying to get content from TikTok"""
 
+class CDPTimeoutException(TikTokException):
+    """A CDP command was sent to the browser and never answered.
+
+    Means the page has stopped servicing the DevTools protocol, so every later command on
+    that connection would hang too — the session is dead and has to be rebuilt.
+
+    Deliberately a plain TikTokException: it is in neither the accounts pool's
+    DATA_LEVEL_EXCEPTIONS (which propagate with no retry — this is not the target's fault)
+    nor ROTATE_EXCEPTIONS (which cooldown the account for minutes — the account is fine, it
+    is the browser that is broken). That drops it into Worker.execute_task's generic handler,
+    which closes the session and rebuilds in place on the same account: the fast recovery
+    this actually wants."""
+
 class ApiFailedException(TikTokException):
     """TikTok API is failing"""
 


### PR DESCRIPTION
## The defect

`Connection.send` ends in `return await tx` on a bare Future. Nothing resolves that future except a reply from the browser, and nothing bounds the wait — so any page that stops servicing DevTools hangs its caller **permanently**, and every call site has to remember to impose its own timeout.

Relying on callers is what kept biting us. `video.bytes()` grew a timeout, which fixed the byte fetch and moved the hang to the listing walk instead. On 2026-08-05 the media backfill lost all three pool workers one at a time over two hours and stopped dead — 3628 mp4s in, 97 of 685 handles done.

The failure was invisible from the log: no traceback, no exit, no error at all. A py-spy dump was the only way to see it:

```
Thread 13004 (idle): "MainThread"
    _poll (asyncio\windows_events.py:825)
    ...
Thread 8196 (idle): "asyncio_0"    _worker (concurrent\futures\thread.py:81)
   ... all 12 thread-pool threads idle
```

Event loop alive with nothing runnable, and every `asyncio.to_thread` worker idle — so no S3 call was stuck either. Everything was awaiting socket I/O that would never arrive. Hourly log volume showed the workers dying one by one: `04h=638, 05h=957, 06h=764, 07h=150, 08h=307, 09h=9`.

## The fix

Bound `send` itself, so every call site is covered — including the ones nobody has thought about yet.

**`CDPTimeoutException`, not `asyncio.TimeoutError`.** The bare one stringifies to `''`, which has already cost one debugging session (`['httpx: ', 'browser: ']`). The named one is in **neither** `DATA_LEVEL_EXCEPTIONS` (propagate, no retry — a dead browser isn't the target's fault) **nor** `ROTATE_EXCEPTIONS` (cooldown the account for minutes — the account is fine, the browser isn't), so it lands in `Worker.execute_task`'s generic handler and **rebuilds the session in place**. That handler's own comment argues for exactly this with a small pool.

**Order matters in `apply_cdp_patches`.** `wait_for` *cancels* the transaction on timeout, so without the dispatch guard from #33 a late reply would hit a cancelled future, raise `InvalidStateError` inside the listener and kill it — converting one bounded hang into a permanently dead connection. Bounding `send` alone would have been worse than not bounding it. The test asserts the guard is installed alongside.

**`type.__setattr__`.** `Connection`'s `CantTouchThis` metaclass rejects every class-level assignment; it exists to stop callers creating shared mutable class state like `websocket`. Replacing a method isn't that, so the patch goes under it deliberately and keeps its idempotency marker on the function rather than the class.

**120s default**, `PYTOK_CDP_TIMEOUT` overrides, `<=0` disables. Real commands answer in milliseconds; the slowest legitimate one is the in-page base64 video fetch, already capped far below this by its caller. This is not a performance knob — it only stops a never-answered command hanging forever.

## Test

```
unpatched: send() still waiting after 1s (would wait forever)  reproduced
patched:   raises CDPTimeoutException  OK
    CDP command get_cookies was not answered within 0.5s — the page has stopped
    servicing DevTools, so this session needs rebuilding
    names other commands too: ...valuate was not answered within 0.5s...
a command that IS answered resolves normally and immediately  OK
CDPTimeoutException in neither DATA_LEVEL nor ROTATE -> rebuild in place  OK
default 120s; PYTOK_CDP_TIMEOUT=0 disables; garbage falls back
transaction dispatch guard installed alongside (a late reply can't kill the listener)
applying twice is a no-op
```

It wraps the real code path: a stand-in `Connection.send` is installed first and the patch wraps *that*, so the wrapper under test is the one that ships. An answered command is also asserted to return in <0.2s, so the bound can't silently add latency.

#33's test still passes, and live against real Chrome with every CDP call wrapped: `theandrewschulz` → `8 videos, mp4s: 8 downloaded, 0 already in S3, 0 photo posts, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)