### PR TITLE
Read TikTok from a real phone's Chrome over adb + CDP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@ PyTok tracks network responses via Chrome DevTools Protocol:
 - `api/base.py` - Base class with DOM interaction, captcha detection, scrolling
 - `api/user.py` - User data and video fetching
 - `api/video.py` - Video metadata, bytes download, comments
+- `phone.py` - Optional third route: drives Chrome on a physical Android phone over
+  adb + CDP to read mobile web (`PhoneTikTok`). Independent of `PyTok`/zendriver and
+  needs no account. First `item_list` page only; see its module docstring for why
 - `helpers.py` - HTML parsing, extracts `__UNIVERSAL_DATA_FOR_REHYDRATION__` JSON from pages
 - `utils.py` - DataFrame conversion helpers (`get_video_df`, `get_comment_df`, `get_user_df`)
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,50 @@ if __name__ == "__main__":
 
 Please do not hesitate to make an issue in this repo to get our help with this!
 
+## Scraping from a physical Android phone
+
+`pytok.phone` is a third data route, alongside the API requests and the desktop browser:
+it drives **Chrome on a real handset** over `adb` + the Chrome DevTools Protocol, reading
+TikTok's mobile web. The phone presents a genuine mobile fingerprint that no desktop
+stealth patch reproduces, and in testing an anonymous phone session returned a full
+listing with no captcha and no login.
+
+```py
+import asyncio
+from pytok.phone import PhoneTikTok, list_serials
+
+async def main():
+    serials = await list_serials()          # phones in adb state "device"
+    async with PhoneTikTok(serials[0]) as phone:
+        user = await phone.user_info("therock")
+        videos = await phone.user_videos("therock")
+        print(user["followerCount"], len(videos))
+
+asyncio.run(main())
+```
+
+`user_info()` returns the same dict shape as `User.info()`, and `user_videos()` returns raw
+`itemList` dicts that go straight into `utils.get_video_df` — so phone-sourced rows join
+cleanly with rows from the other routes.
+
+Phones can live on a remote host (one SSH hop) and are configured by argument or env var:
+
+```bash
+PYTOK_PHONE_SSH=meo-laptop PYTOK_ADB='C:\platform-tools\adb.exe' \
+    python examples/phone_example.py therock
+```
+
+Drive several at once by giving each its own `cdp_port`.
+
+**Two limits worth knowing before you plan a crawl around this.** Phones on one WiFi share
+a single egress IP and TikTok's burst limits are largely IP-level, so N handsets do *not*
+give N times the rate-limit headroom — only SIMs or proxies would. And mobile web serves
+one `item_list` page (~35 videos) per profile: there is no infinite scroll, and the
+response URL is signed over its own query string, so replaying it with an advanced cursor
+returns an empty body. `user_videos()` logs when it hits that ceiling rather than passing a
+truncated listing off as a complete one. Use this route for breadth across many profiles,
+not depth on one.
+
 ## Citation
 
 If you use this library in your research, please cite it using the following BibTeX entry:

--- a/README.md
+++ b/README.md
@@ -175,11 +175,16 @@ Drive several at once by giving each its own `cdp_port`.
 **Two limits worth knowing before you plan a crawl around this.** Phones on one WiFi share
 a single egress IP and TikTok's burst limits are largely IP-level, so N handsets do *not*
 give N times the rate-limit headroom — only SIMs or proxies would. And mobile web serves
-one `item_list` page (~35 videos) per profile: there is no infinite scroll, and the
-response URL is signed over its own query string, so replaying it with an advanced cursor
-returns an empty body. `user_videos()` logs when it hits that ceiling rather than passing a
-truncated listing off as a complete one. Use this route for breadth across many profiles,
-not depth on one.
+one `item_list` page (~35 videos) per profile, with no infinite scroll to drive.
+`user_videos()` logs when it hits that ceiling rather than passing a truncated listing off
+as a complete one. Use this route for breadth across many profiles, not depth on one.
+
+Fetching the next page yourself from inside the page does not work, and the module
+docstring records the measurements in full so nobody re-derives them: TikTok's SDK really
+does re-sign an injected `fetch` (`X-Bogus`/`X-Gnarly` appear on the wire), the request
+headers are identical to the app's own, and `msToken` is not a single-use nonce — yet the
+app's request returns ~82 KB and an identical injected one returns an empty 200. Depth
+needs a logged-in session, not better request forgery.
 
 ## Citation
 

--- a/examples/phone_example.py
+++ b/examples/phone_example.py
@@ -1,0 +1,51 @@
+"""Scrape TikTok mobile web from a physical Android phone over adb + CDP.
+
+Unlike the other examples this one needs no accounts pool: the phone's own mobile Chrome
+session gets profile data anonymously. It does need a handset with USB debugging
+authorized -- see `pytok/phone.py` for the prerequisites and the limits (first item_list
+page only, and no IP diversity between phones on one WiFi).
+
+    # phones on a remote farm laptop:
+    PYTOK_PHONE_SSH=meo-laptop PYTOK_ADB='C:\\platform-tools\\adb.exe' \
+        python examples/phone_example.py therock
+
+    # a phone plugged into this machine:
+    python examples/phone_example.py therock
+"""
+
+import asyncio
+import logging
+import sys
+
+from pytok.phone import PhoneTikTok, list_serials
+from pytok.utils import get_video_df
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def main(username: str) -> None:
+    serials = await list_serials()
+    if not serials:
+        raise SystemExit("no drivable phones -- check `adb devices` and USB debugging")
+    print(f"phones available: {serials}")
+
+    async with PhoneTikTok(serials[0]) as phone:
+        user = await phone.user_info(username)
+        print(f"\n@{user['uniqueId']} -- {user.get('nickname')}")
+        print(f"  followers: {user.get('followerCount'):,}")
+        print(f"  videos:    {user.get('videoCount'):,}")
+
+        videos = await phone.user_videos(username)
+        print(f"\ngot {len(videos)} videos")
+        for video in videos[:5]:
+            stats = video.get("stats", {})
+            print(f"  {video['id']}  plays={stats.get('playCount'):>10,}  "
+                  f"{(video.get('desc') or '')[:50]}")
+
+        if videos:
+            # The raw itemList dicts drop straight into pytok's dataframe helpers.
+            print(f"\ndataframe: {get_video_df(videos).shape}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1] if len(sys.argv) > 1 else "therock"))

--- a/pytok/phone.py
+++ b/pytok/phone.py
@@ -21,11 +21,31 @@ the per-*IP* load. Phones with their own SIMs or proxies would; phones on a shar
 not. Do not size a crawl on the assumption that N phones give N times the headroom.
 
 **Deep pagination.** Mobile web hands over the first `item_list` page (~35 videos) and
-then stops: there is no infinite scroll to drive, and the response URL is signed
-(`msToken` + `X-Bogus` + `X-Gnarly`) over its own query string, so replaying it with an
-advanced cursor returns a 200 with an empty body. Going deeper needs the signing
-machinery in `tiktok_api.py` driven from inside the page, which this module does not do
-yet -- `user_videos()` documents its own ceiling and says when it hit it.
+then stops: there is no infinite scroll to drive. `user_videos()` documents its own
+ceiling and says when it hit it.
+
+Forging the next page from inside the page does not work, and it is worth recording why,
+because the obvious diagnosis is wrong. It is *not* a signing problem:
+
+- TikTok's `webmssdk.js` patches `fetch` and `XMLHttpRequest` (none of them are native),
+  and `/api/post/item_list/` is in its `_mssdk._enablePathList`. A `fetch()` issued from
+  page context with `X-Bogus`/`X-Gnarly` omitted comes back out on the wire *with both
+  freshly added* -- verified against `Network.requestWillBeSentExtraInfo`.
+- Diffing that outgoing request against the app's own: the header sets are identical, no
+  header only one of them sends.
+- `msToken` is not a rotating single-use nonce -- the one in the captured URL and the one
+  in `document.cookie` are the same string.
+
+And yet, seconds apart on one page load, the app's own request returns ~82 KB while ours
+returns a 200 with an empty body -- including when replayed completely unchanged. TikTok
+is separating app-initiated from injected requests on something that is not in the URL or
+the headers, so re-signing harder will not fix it.
+
+Driving the *desktop* bundle from the handset (UA + viewport override) does make the app
+issue its own paginating requests, but anonymously every one of them comes back empty --
+the same thing desktop sessions do without an account. So depth needs a logged-in
+session, not better forgery; the account pool in `pytok.accounts` is the lead worth
+following, not this module.
 
 So: use this for breadth (first page for many profiles, from a fingerprint TikTok treats
 differently), not for depth on one profile.

--- a/pytok/phone.py
+++ b/pytok/phone.py
@@ -1,0 +1,686 @@
+"""Scrape TikTok mobile web by driving Chrome on a physical Android phone over adb + CDP.
+
+A third data route, alongside the two in `tiktok.py` (TikTok-Api requests, and zendriver
+driving a desktop Chrome). Instead of a browser on this machine it drives **Chrome on a
+real handset**:
+
+    wake the phone -> start Chrome -> `adb forward` its DevTools socket -> open a tab at
+    the profile URL -> capture the `/api/...` responses off the wire with CDP -> parse the
+    same payloads the desktop route parses.
+
+Why bother: the handset presents a genuine mobile fingerprint (real touch, real DPR, real
+mobile Chrome build) that no desktop stealth patch reproduces. In testing, an anonymous
+phone session returned a full `item_list` for a profile with no captcha and no login,
+where anonymous desktop sessions mostly come back empty.
+
+What this does NOT buy you
+--------------------------
+**IP diversity.** Every phone on one WiFi shares a single egress IP, and TikTok's burst
+limits are largely IP-level, so rotating handsets spreads the per-*session* load but not
+the per-*IP* load. Phones with their own SIMs or proxies would; phones on a shared AP do
+not. Do not size a crawl on the assumption that N phones give N times the headroom.
+
+**Deep pagination.** Mobile web hands over the first `item_list` page (~35 videos) and
+then stops: there is no infinite scroll to drive, and the response URL is signed
+(`msToken` + `X-Bogus` + `X-Gnarly`) over its own query string, so replaying it with an
+advanced cursor returns a 200 with an empty body. Going deeper needs the signing
+machinery in `tiktok_api.py` driven from inside the page, which this module does not do
+yet -- `user_videos()` documents its own ceiling and says when it hit it.
+
+So: use this for breadth (first page for many profiles, from a fingerprint TikTok treats
+differently), not for depth on one profile.
+
+Prerequisites
+-------------
+- `adb` on the host the phones hang off, and USB debugging authorized per handset
+  (a phone in adb state "unauthorized" still needs its on-screen prompt accepted).
+- Chrome installed on the phone. It need not be logged in.
+- The phone must be **awake**: Chrome does not open its DevTools socket while the screen
+  is off, so a sleeping handset fails with "DevTools socket never appeared". `keep_awake`
+  (default) handles this.
+
+Usage::
+
+    from pytok.phone import PhoneTikTok, list_serials
+
+    serials = await list_serials(ssh_host="meo-laptop", adb=r"C:\\platform-tools\\adb.exe")
+    async with PhoneTikTok(serials[0], ssh_host="meo-laptop",
+                           adb=r"C:\\platform-tools\\adb.exe") as phone:
+        info = await phone.user_info("therock")
+        videos = await phone.user_videos("therock")
+
+The transport here (adb wrapper, CDP tunnel, the three gotchas below) follows
+`ai_scrapers.phone_farm`, which drives the same handsets for Google AI Mode. It is
+reimplemented rather than imported because that one is synchronous and pytok is
+async throughout, and because this needs CDP *network capture*, which it does not do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+import websockets
+
+from .exceptions import (
+    ApiFailedException,
+    CaptchaException,
+    NotFoundException,
+    TikTokException,
+)
+from .utils import LOGGER_NAME
+
+logger = logging.getLogger(LOGGER_NAME)
+
+CHROME_PKG = "com.android.chrome"
+DEFAULT_CDP_PORT = 9222
+PROFILE_URL = "https://www.tiktok.com/@{username}"
+
+# The endpoint worth keeping when it goes past on the wire. Substring match on the URL,
+# because it carries a long signed query string. Profile info does not need capturing:
+# the mobile page ships it in its rehydration payload and never calls /api/user/detail/.
+_ITEM_LIST_EP = "/api/post/item_list/"
+
+
+class PhoneError(TikTokException):
+    """adb / CDP transport failure while driving a phone.
+
+    A TikTokException so callers that already funnel pytok failures into one handler keep
+    working, but distinct from the API/scraping exceptions: it means the *handset* could
+    not be driven, not that TikTok refused us.
+    """
+
+
+# ── adb transport (local, or over one SSH hop) ────────────────────────────────
+
+@dataclass
+class AsyncAdb:
+    """Runs adb, either locally or by prefixing one SSH hop to a remote host."""
+
+    adb: str = "adb"
+    ssh_host: Optional[str] = None
+    timeout: int = 60
+
+    async def _run(self, cmd: str) -> tuple[int, str, str]:
+        if self.ssh_host:
+            proc = await asyncio.create_subprocess_exec(
+                "ssh", self.ssh_host, cmd,
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        else:
+            # The platform's own shell: on a Windows farm host reached locally this is
+            # cmd.exe, and every command built here is plain enough to survive both.
+            proc = await asyncio.create_subprocess_shell(
+                cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            raise PhoneError(f"adb command timed out after {self.timeout}s: {cmd}")
+        return proc.returncode, out.decode(errors="replace"), err.decode(errors="replace")
+
+    async def shell(self, serial: str, script: str) -> str:
+        """Run `adb -s <serial> shell "<script>"`.
+
+        `script` runs in the phone's own sh, so `;`-chaining works. Wrap URLs in single
+        quotes inside it so `&` survives: cmd.exe on a Windows ssh host keeps `&` literal
+        because the whole argument is double-quoted.
+        """
+        _, out, _ = await self._run(f'{self.adb} -s {serial} shell "{script}"')
+        return out
+
+    async def raw(self, serial: str, args: str) -> str:
+        _, out, _ = await self._run(f"{self.adb} -s {serial} {args}")
+        return out
+
+    async def devices(self) -> list[tuple[str, str]]:
+        """`adb devices` as (serial, state) pairs, e.g. ("R5CY23A517W", "device")."""
+        _, out, _ = await self._run(f"{self.adb} devices")
+        pairs = []
+        for line in out.splitlines():
+            line = line.strip()
+            if not line or line.startswith("List of devices") or line.startswith("*"):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                pairs.append((parts[0], parts[1]))
+        return pairs
+
+
+async def list_serials(*, ssh_host: Optional[str] = None, adb: Optional[str] = None,
+                       timeout: int = 60) -> list[str]:
+    """Serials of the phones that are drivable right now.
+
+    Only handsets in adb state "device" are returned. An "unauthorized" one needs its
+    on-screen USB-debugging prompt accepted first, so it stays invisible to a run rather
+    than failing one midway.
+    """
+    transport = AsyncAdb(adb=adb or os.getenv("PYTOK_ADB", "adb"),
+                         ssh_host=ssh_host or os.getenv("PYTOK_PHONE_SSH") or None,
+                         timeout=timeout)
+    pairs = await transport.devices()
+    ready = [s for s, state in pairs if state == "device"]
+    if not ready and pairs:
+        logger.warning("no drivable phones; adb reports: "
+                       + ", ".join(f"{s}={st}" for s, st in pairs))
+    return ready
+
+
+# ── CDP tunnel: adb forward + (optional) SSH -L, kept alive together ──────────
+
+class CdpTunnel:
+    """Expose the phone's Chrome DevTools endpoint at http://127.0.0.1:<port>.
+
+    Three non-obvious things this has to get right, all learned the hard way:
+
+    1. Over SSH the forward is established *inside* the same long-lived process that holds
+       the `-L` tunnel open, so one process owns both ends. The forward itself belongs to
+       the adb server and outlives that process, so `__aexit__` removes it explicitly.
+    2. The tunnel's remote target must be `127.0.0.1`, not `localhost`: the latter can
+       resolve to `::1` while adb binds IPv4, and the connection then hangs.
+    3. `localabstract:chrome_devtools_remote` only exists *while Chrome runs*, so the
+       forward succeeds against a dead Chrome and every connection through it is refused.
+       `PhoneTikTok._ensure_chrome` starts Chrome before the tunnel is built.
+    """
+
+    def __init__(self, adb: AsyncAdb, serial: str, port: int = DEFAULT_CDP_PORT):
+        self._adb = adb
+        self._serial = serial
+        self._port = port
+        self._proc: Optional[asyncio.subprocess.Process] = None
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self._port}"
+
+    async def __aenter__(self) -> "CdpTunnel":
+        fwd = (f"{self._adb.adb} -s {self._serial} forward tcp:{self._port} "
+               f"localabstract:chrome_devtools_remote")
+        if self._adb.ssh_host:
+            # Windows keepalive, killed when we terminate the ssh process. The forward and
+            # the -L tunnel must share one process (gotcha 1 above).
+            keepalive = "ping -n 100000 127.0.0.1 >NUL"
+            self._proc = await asyncio.create_subprocess_exec(
+                "ssh", "-L", f"{self._port}:127.0.0.1:{self._port}",
+                self._adb.ssh_host, f"{fwd} && {keepalive}",
+                stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+        else:
+            rc, out, err = await self._adb._run(fwd)
+            if rc != 0:
+                raise PhoneError(f"`adb forward` failed for {self._serial} (rc {rc}): "
+                                 f"{(err or out).strip()[:200]}")
+        await self._wait_ready()
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        if self._proc is not None:
+            self._proc.terminate()
+            try:
+                await asyncio.wait_for(self._proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self._proc.kill()
+        # Always remove the forward, including over SSH. It is registered with the *adb
+        # server*, a daemon that outlives the client that created it, so killing the ssh
+        # session drops the -L tunnel but leaves the forward behind. Left alone they
+        # accumulate, and a stale one on a port later reused for a different handset
+        # would quietly point at the wrong phone.
+        await self._adb.raw(self._serial, f"forward --remove tcp:{self._port}")
+
+    async def _wait_ready(self, timeout: float = 25.0) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        last: Any = None
+        while loop.time() < deadline:
+            try:
+                await self.get_json("/json/version")
+                return
+            except Exception as ex:  # noqa: BLE001 — retry any transport hiccup
+                last = ex
+                await asyncio.sleep(0.7)
+        raise PhoneError(f"CDP endpoint never came up on {self.base}: {last}")
+
+    async def get_json(self, path: str) -> Any:
+        """GET a DevTools HTTP endpoint.
+
+        Uses httpx rather than a hand-rolled request because Android Chrome's DevTools
+        server keeps the connection open regardless of `Connection: close`, so reading to
+        EOF just hangs until the timeout.
+        """
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(self.base + path)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ── CDP session over the browser-level websocket ──────────────────────────────
+
+class CdpSession:
+    """One websocket to the phone Chrome's browser endpoint, with flat target sessions.
+
+    Attaching at the *browser* level (rather than to a page) is what lets us open our own
+    tab, which matters on these handsets: the farm phones carry hundreds of tabs from
+    other studies, and Chrome on Android freezes backgrounded ones, so reusing an existing
+    tab means talking to a renderer that may never answer.
+    """
+
+    def __init__(self, ws_url: str, response_filter: tuple[str, ...] = ()):
+        self._ws_url = ws_url
+        self._filter = response_filter
+        self._ws: Any = None
+        self._id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._reader: Optional[asyncio.Task] = None
+        # (session_id, request_id, url) for every response matching `response_filter`.
+        self.responses: list[tuple[str, str, str]] = []
+
+    async def __aenter__(self) -> "CdpSession":
+        # 100 MB: a single item_list page came back at ~1 MB, but video payloads and
+        # long comment pages run much larger, and a truncated frame kills the connection.
+        self._ws = await websockets.connect(self._ws_url, max_size=100 * 1024 * 1024)
+        self._reader = asyncio.create_task(self._read_loop())
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        if self._reader:
+            self._reader.cancel()
+        if self._ws:
+            await self._ws.close()
+
+    async def _read_loop(self) -> None:
+        try:
+            async for raw in self._ws:
+                msg = json.loads(raw)
+                if "id" in msg:
+                    fut = self._pending.pop(msg["id"], None)
+                    if fut and not fut.done():
+                        if "error" in msg:
+                            fut.set_exception(PhoneError(f"CDP error: {msg['error']}"))
+                        else:
+                            fut.set_result(msg.get("result", {}))
+                elif msg.get("method") == "Network.responseReceived":
+                    params = msg["params"]
+                    url = params["response"]["url"]
+                    if any(ep in url for ep in self._filter):
+                        self.responses.append(
+                            (msg.get("sessionId", ""), params["requestId"], url))
+        except asyncio.CancelledError:
+            raise
+        except Exception as ex:  # noqa: BLE001 — a dead socket must fail every waiter
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(PhoneError(f"CDP connection lost: {ex}"))
+            self._pending.clear()
+
+    async def call(self, method: str, params: Optional[dict] = None,
+                   session_id: Optional[str] = None, timeout: float = 30.0) -> dict:
+        self._id += 1
+        payload: dict[str, Any] = {"id": self._id, "method": method, "params": params or {}}
+        if session_id:
+            payload["sessionId"] = session_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[self._id] = fut
+        await self._ws.send(json.dumps(payload))
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        except asyncio.TimeoutError:
+            self._pending.pop(self._id, None)
+            raise PhoneError(f"CDP command {method} timed out after {timeout}s")
+
+    async def open_tab(self, url: str = "about:blank") -> tuple[str, str]:
+        """Create a tab, attach to it, enable the domains we read, foreground it.
+
+        Returns (target_id, session_id). `Page.bringToFront` is not cosmetic: Android
+        Chrome throttles background tabs to the point that navigation never completes.
+        """
+        target_id = (await self.call("Target.createTarget", {"url": url}))["targetId"]
+        session_id = (await self.call(
+            "Target.attachToTarget", {"targetId": target_id, "flatten": True}))["sessionId"]
+        for domain in ("Page", "Network", "Runtime"):
+            await self.call(f"{domain}.enable", {}, session_id=session_id)
+        await self.call("Page.bringToFront", {}, session_id=session_id)
+        return target_id, session_id
+
+    async def close_tab(self, target_id: str, session_id: Optional[str] = None) -> None:
+        """Best effort: a tab we cannot close is untidy, not a failed scrape.
+
+        Drops that tab's captured responses too, so a long run over many profiles does not
+        accumulate the whole crawl's wire traffic in memory.
+        """
+        try:
+            await self.call("Target.closeTarget", {"targetId": target_id}, timeout=10)
+        except Exception as ex:  # noqa: BLE001
+            logger.debug(f"could not close phone tab {target_id}: {ex}")
+        if session_id:
+            self.responses = [r for r in self.responses if r[0] != session_id]
+
+    async def evaluate(self, expression: str, session_id: str, timeout: float = 30.0) -> Any:
+        res = await self.call("Runtime.evaluate",
+                              {"expression": expression, "returnByValue": True,
+                               "awaitPromise": True},
+                              session_id=session_id, timeout=timeout)
+        if "exceptionDetails" in res:
+            raise PhoneError(f"JS evaluation failed: {res['exceptionDetails']}")
+        return res.get("result", {}).get("value")
+
+    async def response_body(self, request_id: str, session_id: str) -> Optional[dict]:
+        """Parsed JSON body of a captured response, or None if Chrome no longer has it.
+
+        Bodies are evicted once the renderer garbage-collects them, and an empty body is
+        TikTok's own way of refusing a request, so neither case is an error here.
+        """
+        try:
+            res = await self.call("Network.getResponseBody", {"requestId": request_id},
+                                  session_id=session_id, timeout=30)
+        except PhoneError as ex:
+            logger.debug(f"response body unavailable for {request_id}: {ex}")
+            return None
+        body = res.get("body") or ""
+        if not body.strip():
+            return None
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            logger.debug(f"response body for {request_id} was not JSON ({len(body)} bytes)")
+            return None
+
+
+# ── the scraper ───────────────────────────────────────────────────────────────
+
+# One round trip: everything we want to know about the loaded profile page. Returned as a
+# string so one `returnByValue` carries it whole.
+_PAGE_STATE_JS = r"""
+(() => {
+  const el = document.getElementById('__UNIVERSAL_DATA_FOR_REHYDRATION__');
+  const text = document.body ? document.body.innerText : '';
+  return JSON.stringify({
+    url: location.href,
+    rehydration: el ? el.textContent : null,
+    text: text.slice(0, 2000),
+    captcha: !!document.querySelector('[id*=captcha], [class*=captcha]'),
+  });
+})()
+"""
+
+
+class PhoneTikTok:
+    """Drive one Android handset's Chrome to read TikTok mobile web.
+
+    Args:
+        serial: the phone's adb serial (see `list_serials`).
+        ssh_host: SSH host the phone hangs off; None drives a locally attached phone.
+            Falls back to env `PYTOK_PHONE_SSH`.
+        adb: path to adb on that host. Falls back to env `PYTOK_ADB`, else "adb".
+            On the MEO farm laptop that is ``C:\\platform-tools\\adb.exe``.
+        cdp_port: local+remote TCP port for the DevTools forward. Give concurrent
+            handsets different ports.
+        page_timeout_s: how long to wait for a profile page to become readable. A
+            budget, not a sleep -- a page that loads fast is read as soon as it does.
+        listing_timeout_s: how long to wait for the profile's own `item_list` request
+            to come back before treating the listing as failed.
+        keep_awake: hold the screen on for the session. Chrome will not open its
+            DevTools socket while the phone sleeps, so leaving this off means driving
+            a phone something else is keeping awake.
+
+    Use as an async context manager and reuse one instance across profiles::
+
+        async with PhoneTikTok("R5CY23A5E7Y", ssh_host="meo-laptop") as phone:
+            info = await phone.user_info("therock")
+    """
+
+    def __init__(self, serial: str, *, ssh_host: Optional[str] = None,
+                 adb: Optional[str] = None, cdp_port: int = DEFAULT_CDP_PORT,
+                 page_timeout_s: float = 45.0, listing_timeout_s: float = 45.0,
+                 keep_awake: bool = True, sleep_on_exit: bool = False):
+        self.serial = serial
+        self._adb = AsyncAdb(adb=adb or os.getenv("PYTOK_ADB", "adb"),
+                             ssh_host=ssh_host or os.getenv("PYTOK_PHONE_SSH") or None)
+        self.cdp_port = cdp_port
+        self.page_timeout_s = page_timeout_s
+        self.listing_timeout_s = listing_timeout_s
+        self.keep_awake = keep_awake
+        self.sleep_on_exit = sleep_on_exit
+        self._tunnel: Optional[CdpTunnel] = None
+        self._cdp: Optional[CdpSession] = None
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def __aenter__(self) -> "PhoneTikTok":
+        if self.keep_awake:
+            await self.wake()
+        await self._ensure_chrome()
+        self._tunnel = CdpTunnel(self._adb, self.serial, self.cdp_port)
+        await self._tunnel.__aenter__()
+        # From here on, anything that fails has to undo the tunnel by hand: `async with`
+        # does not call __aexit__ when __aenter__ raises, and the adb forward would
+        # outlive the process that made it.
+        try:
+            version = await self._tunnel.get_json("/json/version")
+            ws_url = version["webSocketDebuggerUrl"].replace("localhost", "127.0.0.1")
+            logger.info(f"[phone {self.serial}] driving {version.get('Browser')}")
+            self._cdp = CdpSession(ws_url, response_filter=(_ITEM_LIST_EP,))
+            await self._cdp.__aenter__()
+        except Exception:
+            await self._tunnel.__aexit__(None, None, None)
+            self._tunnel = None
+            raise
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        if self._cdp is not None:
+            await self._cdp.__aexit__(*exc)
+        if self._tunnel is not None:
+            await self._tunnel.__aexit__(*exc)
+        if self.sleep_on_exit:
+            await self._adb.shell(self.serial, "svc power stayon false; input keyevent KEYCODE_SLEEP")
+
+    async def wake(self) -> None:
+        """Wake and unlock the screen, and hold it on for the session."""
+        await self._adb.shell(
+            self.serial,
+            "input keyevent KEYCODE_WAKEUP; wm dismiss-keyguard; svc power stayon true")
+
+    async def _ensure_chrome(self, timeout: float = 45.0) -> None:
+        """Start Chrome and wait for its DevTools socket to exist.
+
+        Launching on about:blank rather than straight at the profile keeps this step
+        independent of what we are about to scrape, so a failure here is unambiguously
+        "the phone would not give us a browser".
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        launched = False
+        while loop.time() < deadline:
+            sockets = await self._adb.shell(
+                self.serial, "cat /proc/net/unix | grep chrome_devtools_remote")
+            if "chrome_devtools_remote" in sockets:
+                return
+            if not launched:
+                await self._adb.shell(
+                    self.serial,
+                    f"am start -a android.intent.action.VIEW -d 'about:blank' {CHROME_PKG}")
+                launched = True
+            await asyncio.sleep(1.0)
+        raise PhoneError(
+            f"Chrome's DevTools socket never appeared on {self.serial} after {timeout:.0f}s "
+            f"-- is Chrome installed, USB debugging authorized, and the screen awake?")
+
+    # -- scraping -------------------------------------------------------------
+
+    async def _load_profile(self, username: str) -> tuple[str, str, dict]:
+        """Open a tab at a profile and return (target_id, session_id, page state)."""
+        if self._cdp is None:
+            raise PhoneError("PhoneTikTok used outside its `async with` block")
+        url = PROFILE_URL.format(username=username)
+        target_id, session_id = await self._cdp.open_tab()
+        try:
+            await self._cdp.call("Page.navigate", {"url": url},
+                                 session_id=session_id, timeout=90)
+            state = await self._await_page_state(session_id)
+        except Exception:
+            await self._cdp.close_tab(target_id, session_id)
+            raise
+        if state.get("captcha"):
+            await self._cdp.close_tab(target_id, session_id)
+            raise CaptchaException(f"phone {self.serial} was served a captcha for @{username}")
+        return target_id, session_id, state
+
+    async def _await_page_state(self, session_id: str) -> dict:
+        """Poll the loaded page until its rehydration payload appears.
+
+        Polling rather than sleeping a flat interval, because how long a profile takes to
+        become readable varies by more than an order of magnitude across handsets: a phone
+        carrying hundreds of other tabs starts its renderer slowly, and one fixed wait
+        either gives up too early there or burns the difference on an idle phone.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.page_timeout_s
+        state: dict = {}
+        while loop.time() < deadline:
+            raw = await self._cdp.evaluate(_PAGE_STATE_JS, session_id)
+            state = json.loads(raw) if raw else {}
+            if state.get("rehydration") or state.get("captcha"):
+                return state
+            await asyncio.sleep(1.0)
+        return state
+
+    async def _await_listing(self, session_id: str) -> bool:
+        """Wait for this tab's `item_list` request to come back. False if it never did."""
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self.listing_timeout_s
+        while loop.time() < deadline:
+            if any(sid == session_id for sid, _, _ in self._cdp.responses):
+                return True
+            await asyncio.sleep(0.5)
+        return False
+
+    @staticmethod
+    def _user_from_rehydration(state: dict, username: str) -> dict:
+        """Pull the user out of the page's rehydration blob, in `User.info()`'s shape.
+
+        Mobile web ships the same `__UNIVERSAL_DATA_FOR_REHYDRATION__` payload the desktop
+        page does, so this returns `{**user, **stats}` exactly as `_info_full_scrape` does
+        and the result drops into `utils.get_user_df` unchanged.
+        """
+        blob = state.get("rehydration")
+        if not blob:
+            text = state.get("text", "")
+            if "Couldn't find this account" in text:
+                raise NotFoundException(f"TikTok says @{username} does not exist")
+            raise ApiFailedException(
+                f"no rehydration data on the mobile profile page for @{username} "
+                f"(page text began: {text[:120]!r})")
+        try:
+            scope = json.loads(blob)["__DEFAULT_SCOPE__"]
+        except (json.JSONDecodeError, KeyError) as ex:
+            raise ApiFailedException(f"malformed rehydration data for @{username}: {ex}")
+
+        detail = scope.get("webapp.user-detail", {})
+        status = detail.get("statusCode")
+        if status in (10202, 10221, 100002):
+            raise NotFoundException(
+                f"TikTok indicated @{username} does not exist: statusCode={status}")
+        if status not in (0, None):
+            raise ApiFailedException(
+                f"TikTok returned statusCode={status} for @{username} on mobile web")
+
+        user_info = detail.get("userInfo", {})
+        user = {**user_info.get("user", {}), **user_info.get("stats", {})}
+        if not user.get("id"):
+            raise ApiFailedException(f"no user data in the mobile page payload for @{username}")
+        return user
+
+    async def user_info(self, username: str) -> dict:
+        """Profile info for one user, in the same shape as `User.info()`.
+
+        Reads the page's own rehydration payload rather than issuing an API call, so this
+        costs exactly one page load and needs no request signing.
+        """
+        target_id, session_id, state = await self._load_profile(username)
+        try:
+            user = self._user_from_rehydration(state, username)
+            logger.info(f"[phone {self.serial}] @{username}: "
+                        f"{user.get('followerCount')} followers, "
+                        f"{user.get('videoCount')} videos")
+            return user
+        finally:
+            await self._cdp.close_tab(target_id, session_id)
+
+    async def user_videos(self, username: str, count: Optional[int] = None) -> list[dict]:
+        """The user's most recent videos, as raw `itemList` dicts.
+
+        Returns what the profile's own first `item_list` request returned -- the dicts go
+        straight into `utils.get_video_df`. Mobile web fetches one page (~35 videos) and
+        does not paginate further; see the module docstring for why going deeper needs
+        request signing. When the listing is capped rather than exhausted this logs the
+        ceiling it hit, so a short result is never mistaken for a short profile.
+        """
+        target_id, session_id, state = await self._load_profile(username)
+        try:
+            # An empty profile is a legitimate answer, but a *blocked* one also looks
+            # empty, so cross-check against the count the profile itself reports -- the
+            # same discriminator `User._iter_videos` uses.
+            try:
+                expected = self._user_from_rehydration(state, username).get("videoCount")
+            except (ApiFailedException, NotFoundException):
+                expected = None
+
+            await self._await_listing(session_id)
+
+            # Only this tab's responses: one instance scrapes many profiles in a row, and
+            # the capture list is per-connection, so matching on the session keeps the
+            # previous profile's listing out of this one's.
+            captured = [(rid, url) for sid, rid, url in self._cdp.responses
+                        if sid == session_id]
+            videos: list[dict] = []
+            seen: set[str] = set()
+            has_more = None
+            readable = 0
+            for request_id, _url in captured:
+                body = await self._cdp.response_body(request_id, session_id)
+                if not body:
+                    continue
+                readable += 1
+                has_more = body.get("hasMore", has_more)
+                for item in body.get("itemList") or []:
+                    if item.get("id") and item["id"] not in seen:
+                        seen.add(item["id"])
+                        videos.append(item)
+
+            if not videos:
+                # Three different things look like "no videos" here, and they call for
+                # different responses from a caller, so say which one happened. The
+                # empty-body case is the common one: TikTok answers a listing it is
+                # throttling with a 200 and nothing in it.
+                if not captured:
+                    raise ApiFailedException(
+                        f"@{username}'s profile page never requested its video listing "
+                        f"within {self.listing_timeout_s:.0f}s -- the page did not finish "
+                        f"loading on phone {self.serial}")
+                if not readable:
+                    raise ApiFailedException(
+                        f"TikTok answered the video listing for @{username} with an empty "
+                        f"body -- the request was refused rather than the profile being "
+                        f"empty (commonly rate-limiting; phones on one WiFi share an "
+                        f"egress IP, so backing off is per-IP not per-phone)")
+                if expected:
+                    raise ApiFailedException(
+                        f"no videos returned for @{username} though the profile reports "
+                        f"{expected} -- the mobile listing failed rather than being empty")
+                logger.info(f"[phone {self.serial}] @{username} has no videos")
+                return []
+
+            if count is not None:
+                videos = videos[:count]
+            elif has_more:
+                logger.info(
+                    f"[phone {self.serial}] @{username}: returning {len(videos)} videos but "
+                    f"TikTok reports more"
+                    + (f" (profile says {expected})" if expected else "")
+                    + " -- mobile web serves one item_list page and cannot paginate further")
+            return videos
+        finally:
+            await self._cdp.close_tab(target_id, session_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ tqdm
 pyvirtualdisplay
 pandas
 polars
+httpx
+websockets

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
         "zendriver",
         "requests",
         "httpx",
+        "websockets",
         "brotli",
         "opencv-python",
         "numpy",

--- a/tests/test_phone.py
+++ b/tests/test_phone.py
@@ -1,0 +1,99 @@
+"""Tests for the phone (adb + CDP) backend.
+
+The parsing tests run anywhere. The live test needs a handset, so it is opt-in::
+
+    PYTOK_PHONE_SERIAL=R5CY23A5E7Y PYTOK_PHONE_SSH=meo-laptop \
+        PYTOK_ADB='C:\\platform-tools\\adb.exe' pytest tests/test_phone.py
+"""
+
+import json
+import os
+
+import pytest
+
+from pytok.exceptions import ApiFailedException, NotFoundException
+from pytok.phone import PhoneTikTok
+
+
+def _state(detail, text="") -> dict:
+    """A `_load_profile` page state carrying the given `webapp.user-detail` scope."""
+    return {
+        "rehydration": json.dumps({"__DEFAULT_SCOPE__": {"webapp.user-detail": detail}}),
+        "text": text,
+        "captcha": False,
+    }
+
+
+def test_user_from_rehydration_merges_user_and_stats():
+    """The returned dict is `{**user, **stats}` -- the shape `User.info()` gives callers."""
+    state = _state({
+        "statusCode": 0,
+        "userInfo": {
+            "user": {"id": "5831967", "uniqueId": "therock", "nickname": "The Rock"},
+            "stats": {"followerCount": 79_700_000, "videoCount": 558},
+        },
+    })
+
+    user = PhoneTikTok._user_from_rehydration(state, "therock")
+
+    assert user["id"] == "5831967"
+    assert user["uniqueId"] == "therock"
+    assert user["followerCount"] == 79_700_000
+    assert user["videoCount"] == 558
+
+
+@pytest.mark.parametrize("status_code", [10202, 10221, 100002])
+def test_user_from_rehydration_missing_account(status_code):
+    """TikTok's "no such user" codes are a fact about the handle, not a failed scrape."""
+    with pytest.raises(NotFoundException):
+        PhoneTikTok._user_from_rehydration(_state({"statusCode": status_code}), "nobody")
+
+
+def test_user_from_rehydration_other_status_is_a_failure():
+    with pytest.raises(ApiFailedException):
+        PhoneTikTok._user_from_rehydration(_state({"statusCode": 10101}), "someone")
+
+
+def test_user_from_rehydration_no_blob_reads_the_page_text():
+    """A profile page with no payload is ambiguous, so the visible text breaks the tie."""
+    with pytest.raises(NotFoundException):
+        PhoneTikTok._user_from_rehydration(
+            {"rehydration": None, "text": "Couldn't find this account"}, "nobody")
+
+    with pytest.raises(ApiFailedException):
+        PhoneTikTok._user_from_rehydration(
+            {"rehydration": None, "text": "Something else entirely"}, "someone")
+
+
+def test_user_from_rehydration_rejects_a_payload_with_no_user():
+    """statusCode 0 but no user id: a degraded response, not an account with no data."""
+    with pytest.raises(ApiFailedException):
+        PhoneTikTok._user_from_rehydration(
+            _state({"statusCode": 0, "userInfo": {"user": {}, "stats": {}}}), "someone")
+
+
+def test_user_from_rehydration_malformed_json():
+    with pytest.raises(ApiFailedException):
+        PhoneTikTok._user_from_rehydration(
+            {"rehydration": "{not json", "text": ""}, "someone")
+
+
+@pytest.mark.skipif(not os.getenv("PYTOK_PHONE_SERIAL"),
+                    reason="needs a phone; set PYTOK_PHONE_SERIAL")
+async def test_live_phone_user_info_and_videos():
+    from pytok.utils import get_video_df
+
+    async with PhoneTikTok(os.environ["PYTOK_PHONE_SERIAL"]) as phone:
+        user = await phone.user_info("therock")
+        assert user["uniqueId"] == "therock"
+        assert user["followerCount"] > 0
+
+        videos = await phone.user_videos("therock")
+        assert videos, "mobile web returned no videos for a profile that has them"
+        assert all(v.get("id") for v in videos)
+        # The raw itemList dicts must stay compatible with pytok's dataframe helpers.
+        assert len(get_video_df(videos)) == len(videos)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Adds `pytok.phone` — a third data route alongside the API requests and the desktop browser. It drives Chrome on a **physical Android handset** over `adb` + the DevTools protocol and reads TikTok mobile web.

```py
from pytok.phone import PhoneTikTok, list_serials

serials = await list_serials()
async with PhoneTikTok(serials[0]) as phone:
    user = await phone.user_info("therock")      # same shape as User.info()
    videos = await phone.user_videos("therock")  # raw itemList dicts
```

## Why

The handset presents a genuine mobile fingerprint no desktop stealth patch reproduces. An anonymous phone session returns a full profile **and** video listing with no captcha and no login — where anonymous desktop sessions mostly come back empty. Output shapes match the existing routes, so phone-sourced rows drop straight into `utils.get_video_df` and join cleanly with everything else.

## Two limits, surfaced rather than papered over

Both would otherwise be mistaken for something they aren't, so they're in the module docstring, the README, and the error messages:

- **No IP diversity.** Phones on one WiFi share an egress IP and TikTok's burst limits are largely IP-level, so N handsets do *not* give N times the rate-limit headroom. Only SIMs or proxies would. Don't size a crawl on the phone count.
- **First page only.** Mobile web serves one `item_list` page (~35 videos) per profile, with no infinite scroll to drive. See the pagination section below — the obvious explanation for this turns out to be wrong, and the module records the measurements.

`user_videos()` logs when it hits that ceiling instead of passing a truncated listing off as complete, and distinguishes three failure modes that all look like "no videos": the page never requested its listing, TikTok refused the listing (empty body — usually rate-limiting), and the profile genuinely has none.

## Why the next page can't just be fetched (measured, second commit)

The intuitive diagnosis — "the URL is signed, so an advanced cursor invalidates it" — is **wrong**, and the module docstring records the evidence so nobody spends another afternoon of handset time on it. Signing is not what blocks pagination:

| Check | Result |
|---|---|
| Is `fetch`/`XHR` patched by `webmssdk`? | Yes — none are native, and `/api/post/item_list/` is in `_mssdk._enablePathList` |
| Does an injected `fetch` get re-signed? | **Yes** — omit `X-Bogus`/`X-Gnarly` and both come back *freshly added* on the wire (verified via `Network.requestWillBeSentExtraInfo`, not inferred) |
| Any header the app sends that we don't? | **None**, in either direction |
| Is `msToken` a rotating single-use nonce? | **No** — the URL's copy and `document.cookie`'s are the same string |
| Replay the captured URL completely unchanged? | Empty 200 |

Seconds apart on a single page load, the app's own request returns ~82 KB while an identical injected one returns a 200 with an empty body. TikTok separates app-initiated from injected requests on something that is not in the URL or the headers — re-signing harder cannot fix it.

Driving the **desktop** bundle from the handset (UA + viewport override) does get the app to issue its own paginating requests — 5 of them — but anonymously every one comes back empty, which is the behaviour desktop sessions already have without an account. Same phone, same profile, minutes after mobile returned 82 KB.

**Conclusion: depth needs a logged-in session, not better forgery.** That points at `pytok.accounts` (a phone Chrome logged into a pooled account, then desktop mode for real infinite scroll) rather than at this module. Breadth-across-profiles, which is what this PR delivers, is unaffected.

## Relationship to `ai-scrapers`

The transport follows `ai_scrapers.phone_farm`, which drives the same handsets for Google AI Mode. Reimplemented rather than imported because that one is synchronous while pytok is async throughout, and because this needs CDP **network capture** rather than DOM evaluation.

## Four things that only showed up against real hardware

- Chrome doesn't open its DevTools socket while the screen is off — the session wakes the phone before looking for it.
- Android Chrome freezes background tabs, so a scrape opens its **own** tab and foregrounds it. Reusing an existing tab on these phones (which carry hundreds from other studies) means talking to a renderer that may never answer.
- The `adb forward` belongs to the adb *server* and outlives the ssh session that created it, so it's removed explicitly — including when `__aenter__` fails partway, where `async with` never calls `__aexit__`.
- Android Chrome's DevTools HTTP server ignores `Connection: close`, so HTTP calls go through `httpx` rather than a hand-rolled read to EOF.

Page and listing waits poll for the actual signal rather than sleeping a flat interval: a phone carrying hundreds of tabs starts its renderer an order of magnitude slower than an idle one, and one fixed wait either fails there or wastes seconds everywhere else.

## Testing

Live against six Samsung SM-A166W/A145P handsets (Android 16, Chrome 150) on a remote farm laptop over one SSH hop:

- `user_info` / `user_videos` on several profiles; 35 videos with full stats → `get_video_df` at (35, 56)
- per-tab isolation verified across consecutive profiles (no cross-contamination)
- two phones concurrently on separate CDP ports, ~17s each
- missing account → `NotFoundException`; unauthorized device → `PhoneError` naming the cause
- no leaked adb forwards after clean exit **or** failed enter

`tests/test_phone.py` covers the payload parsing offline (7 cases, all passing); the live test is opt-in via `PYTOK_PHONE_SERIAL`. Note there's no pytest in either local conda env, so those were executed directly rather than through the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
