### PR TITLE
Let a person drive the login instead of the stored credentials

### DIFF
--- a/pytok/accounts/cli.py
+++ b/pytok/accounts/cli.py
@@ -286,8 +286,16 @@ def release(ctx, username):
                    "the source template is copied, never mutated.")
 @click.option("--force-relogin", is_flag=True,
               help="Clear the profile's session and force a fresh login (recover a stale account)")
+@click.option("--manual-login", is_flag=True,
+              help="Sign in by hand in the browser window instead of driving the stored "
+                   "credentials. Use this when the automatic flow cannot get past a captcha: "
+                   "you type the username and password and solve the challenge, then this "
+                   "captures the identity and cookies once you are in.")
+@click.option("--timeout", default=None, type=int,
+              help="Seconds to wait for the login to complete (default 300, or 600 with "
+                   "--manual-login, since typing credentials and solving a captcha takes longer)")
 @click.pass_context
-def login(ctx, username, headless, seed_profile, force_relogin):
+def login(ctx, username, headless, seed_profile, force_relogin, manual_login, timeout):
     """Open a browser for this account, log in, and capture identity + cookies.
 
     Use this once per new account: it launches the account's persistent Chrome
@@ -300,8 +308,23 @@ def login(ctx, username, headless, seed_profile, force_relogin):
 
     Pass --force-relogin to recover an account whose cookies look valid but whose
     session TikTok has invalidated (app-context shows no logged-in user).
+
+    Pass --manual-login to sign in yourself in the browser window rather than having
+    the stored credentials typed in. This is the way past a captcha the solver cannot
+    read, which the automatic flow can only fail on. Combine the two to recover a
+    stale account that also needs a challenge solved:
+
+        cli login --username you@example.com --force-relogin --manual-login
+
+    Completion is detected by polling for the session, so no console is needed and it
+    works when driven from a scheduled task or over ssh. It does need a real desktop
+    for the browser, so --manual-login and --headless are mutually exclusive.
     """
     from ..tiktok import PyTok
+
+    if manual_login and headless:
+        raise click.UsageError("--manual-login needs a visible browser; drop --headless")
+    login_timeout = timeout if timeout is not None else (600 if manual_login else 300)
 
     async def _login():
         pool = AccountsPool(ctx.obj["db"])
@@ -314,8 +337,13 @@ def login(ctx, username, headless, seed_profile, force_relogin):
                 _seed_profile_dir(seed_profile, account.profile_dir)
                 click.echo(f"Seeded warmed profile: {os.path.expanduser(seed_profile)} "
                            f"-> {account.profile_dir}")
+            if manual_login:
+                click.echo(f"Manual login: a browser will open on {account.username}'s profile. "
+                           f"Sign in there and solve any challenge; this waits up to "
+                           f"{login_timeout}s and stores the session once you are in.")
             async with PyTok(account=account, accounts_pool=pool, headless=headless,
-                             force_relogin=force_relogin) as api:
+                             force_relogin=force_relogin, manual_login=manual_login,
+                             login_timeout=login_timeout) as api:
                 ident = await api._get_logged_in_identity()
                 if ident:
                     click.echo(f"Logged in as @{ident.get('unique_id')} (uid {ident.get('user_id')})")

--- a/pytok/tiktok.py
+++ b/pytok/tiktok.py
@@ -98,6 +98,8 @@ class PyTok:
             accounts_pool=None,
             release_on_shutdown: bool = True,
             force_relogin: bool = False,
+            manual_login: bool = False,
+            login_timeout: int = 300,
             startup_lock: Optional[asyncio.Lock] = None,
     ):
         """The PyTok class. Used to interact with TikTok.
@@ -165,6 +167,12 @@ class PyTok:
         # fresh credentialed login — used to recover an account whose cookies look
         # valid but whose session TikTok has invalidated server-side.
         self._force_relogin = force_relogin
+        # When True, verification hands the login to whoever is at the browser instead of
+        # driving it from the stored credentials. The automatic flow cannot get past a
+        # captcha the solver fails to read, which is a dead end for an account that needs
+        # one; a person can type the credentials and solve it.
+        self._manual_login = manual_login
+        self._login_timeout = login_timeout
         # Set True only once the live logged-in uid is confirmed to match the
         # account. Gates cookie snapshots so a stale/unverified session can never
         # overwrite a good cookie backup.
@@ -681,8 +689,9 @@ class PyTok:
         timeout : int, optional
             Maximum time in seconds to wait for login completion (default: 300)
         wait_for_input : bool, optional
-            If True (default), waits for you to press Enter after logging in
-            manually. If False, polls for login cookies until timeout.
+            If True, waits for you to press Enter after logging in manually.
+            If False (default), polls for login cookies until timeout — which is
+            what a caller with no console attached needs.
 
         Returns
         -------
@@ -1122,9 +1131,18 @@ class PyTok:
                     await _confirm(ident)
                     return
 
-        # 3) Fall back to an interactive/credentialed login.
+        # 3) Fall back to an interactive/credentialed login. Withholding the credentials is
+        # what selects login()'s manual path, so a person drives the whole flow.
         self.logger.info(f"No valid session for {account.username}; running login flow")
-        ok = await self.login(username=account.username, password=account.password)
+        if self._manual_login:
+            self.logger.info(
+                f"Manual login: complete the sign-in for {account.username} in the browser "
+                f"window (waiting up to {self._login_timeout}s)"
+            )
+            ok = await self.login(timeout=self._login_timeout)
+        else:
+            ok = await self.login(username=account.username, password=account.password,
+                                  timeout=self._login_timeout)
         if not ok:
             if pool:
                 await pool.set_active(account.username, False, "Login failed during verification")


### PR DESCRIPTION
## Why

Recovering an account whose session TikTok has invalidated means logging in again — and the automatic flow **cannot get past a captcha the solver fails to read**. It fills the credentials, the challenge appears, and the login times out:

```
Captcha solve failed: No captcha response found   (repeatedly)
TimeoutException: Login not completed within 300 seconds
```

There was no way to hand that step to a person at the browser, so such an account couldn't be recovered through the CLI at all.

## What

`PyTok.login` already dispatches to `_manual_login` when credentials are withheld — only `_verify_account` stood in the way, since it always passed the stored ones. It now withholds them under `manual_login`, so the existing path runs.

Exposed as `cli login --manual-login`. Composes with `--force-relogin`, which is the combination a stale account needs:

```
cli login --username you@example.com --force-relogin --manual-login
```

Notes on the two smaller decisions:

- **`--timeout` defaults to 600s in manual mode** (300 otherwise). Typing credentials and solving a challenge doesn't fit the automatic flow's budget.
- **Completion is detected by polling** for the session, not by waiting on stdin, so it works when driven from a scheduled task or over ssh with no console. `_manual_login`'s `wait_for_input` path is left unused for that reason.
- **`--manual-login` refuses `--headless`** — it needs a real desktop for the browser.

Also corrected `login()`'s docstring, which described `wait_for_input` as defaulting to `True` when it defaults to `False` — the opposite of what a caller with no console needs to know.

## Testing

- `login --help` renders; `--manual-login --headless` is rejected with a `UsageError`.
- Dispatch verified by stubbing the browser and tracing `_verify_account`: `manual_login=False` takes the credentialed path, `manual_login=True` takes the manual one, and `login_timeout` threads through to `login()` in both.

Not yet exercised against a live captcha — that needs someone at the worker's desktop, which is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)