### PR TITLE
Manual-login follow-ups that missed the #37 merge

### DIFF
--- a/pytok/tiktok.py
+++ b/pytok/tiktok.py
@@ -171,7 +171,8 @@ class PyTok:
         # driving it from the stored credentials. The automatic flow cannot get past a
         # captcha the solver fails to read, which is a dead end for an account that needs
         # one; a person can type the credentials and solve it.
-        self._manual_login = manual_login
+        # not _manual_login: that is the method this flag ends up calling
+        self._use_manual_login = manual_login
         self._login_timeout = login_timeout
         # Set True only once the live logged-in uid is confirmed to match the
         # account. Gates cookie snapshots so a stale/unverified session can never
@@ -1134,7 +1135,7 @@ class PyTok:
         # 3) Fall back to an interactive/credentialed login. Withholding the credentials is
         # what selects login()'s manual path, so a person drives the whole flow.
         self.logger.info(f"No valid session for {account.username}; running login flow")
-        if self._manual_login:
+        if self._use_manual_login:
             self.logger.info(
                 f"Manual login: complete the sign-in for {account.username} in the browser "
                 f"window (waiting up to {self._login_timeout}s)"

--- a/pytok/tiktok.py
+++ b/pytok/tiktok.py
@@ -1152,8 +1152,28 @@ class PyTok:
         # login() short-circuits on the presence of session cookies, which can be
         # stale server-side (logged in per cookies, but app-context has no user).
         # Require a real, matching identity read before trusting the session.
-        ident = await self._get_logged_in_identity(navigate=True)
+        #
+        # Retried, because a just-completed login is still settling: TikTok redirects to the
+        # home page after sign-in and the app context carries no user until that lands. A
+        # single read here fails on a login that in fact succeeded, and the account is then
+        # marked inactive with a session that works -- which no later run can repair, since
+        # the cookies it left behind make login() short-circuit on every retry.
+        ident = await self._identity_with_retries(
+            lambda: self._get_logged_in_identity(navigate=True)
+        )
         if not ident:
+            # Drop the cookies we just judged unusable. Leaving them made the account
+            # unrecoverable: they are enough for login() to short-circuit on the next run, so
+            # every later attempt reported success without ever showing a login form, failed
+            # this same check, and disabled the account again.
+            try:
+                await self._page.send(cdp.network.clear_browser_cookies())
+                self.logger.info(
+                    f"Cleared the unusable session for {account.username} so the next login "
+                    f"starts from a real sign-in rather than short-circuiting on these cookies"
+                )
+            except Exception as e:
+                self.logger.debug(f"clear_browser_cookies failed: {e}")
             if pool:
                 await pool.set_active(
                     account.username, False,
@@ -1161,7 +1181,8 @@ class PyTok:
                 )
             raise LoginException(
                 f"Account {account.username} appears logged in by cookies but TikTok "
-                f"shows no user (session expired/invalid); clear its profile and re-login"
+                f"shows no user (session expired/invalid); the stale cookies have been "
+                f"cleared, so re-running the login will present a sign-in form"
             )
         if account.user_id and ident.get('user_id') and ident['user_id'] != account.user_id:
             raise LoginException(
@@ -1169,6 +1190,27 @@ class PyTok:
                 f"but account {account.username} expects uid {account.user_id}"
             )
         await _confirm(ident)
+
+    async def _identity_with_retries(self, read, attempts: int = 5, delay: int = 3) -> Optional[dict]:
+        """Read the logged-in identity, retrying while a fresh session settles.
+
+        Returns the first non-empty read, or None once the attempts run out. The wait is
+        short and only paid on the failing path, where the alternative is disabling an
+        account whose session is fine.
+        """
+        for attempt in range(1, attempts + 1):
+            ident = await read()
+            if ident:
+                if attempt > 1:
+                    self.logger.info(f"Identity readable on attempt {attempt}")
+                return ident
+            if attempt < attempts:
+                self.logger.info(
+                    f"No identity yet (attempt {attempt}/{attempts}); the session may still "
+                    f"be settling, retrying in {delay}s"
+                )
+                await asyncio.sleep(delay)
+        return None
 
     async def _identity_after_reload(self, matcher) -> Optional[dict]:
         """Reload tiktok.com (so injected cookies take effect) then run matcher."""


### PR DESCRIPTION
#37 was merged at 15:05 UTC with only its first commit. These two were pushed to the branch afterwards and never landed, so `master` currently ships `--manual-login` **broken**.

## 1. `self._manual_login` shadowed the method it calls

```python
self._manual_login = manual_login      # overwrites the bound _manual_login method
...
return await self._manual_login(timeout, wait_for_input)
#            TypeError: 'bool' object is not callable
```

Every `--manual-login` invocation on current master dies here. Renamed the attribute to `_use_manual_login`; verified by AST sweep that no other `PyTok` attribute shadows a method.

The test that let this through only stubbed `login`, so the dispatch it claimed to check never reached the real method. Replaced with one that stubs just the browser primitives and lets the real `login()` and `_manual_login()` run.

## 2. A settling session disabled the account that had just logged in

The manual sign-in succeeded — TikTok wrote six-month session cookies — but the identity read fired while the post-login redirect to the home page was still in flight, read an empty app context, and `_verify_account` disabled the account. Step 2 already retried this read via `_identity_after_reload`; step 3 did not. Now retried 5×/3s, paid only on the path that would otherwise disable a working account.

**And that failure was self-perpetuating**, which is why the account it was found on sat broken for over a week. The disabled account kept its cookies, and those are enough for `login()` to short-circuit on:

```python
if await self._is_logged_in():
    return True          # cookie presence only
```

So every later attempt reported success without showing a sign-in form, failed the same identity check, and disabled the account again. The failure branch now clears the cookies it just judged unusable, so the next login starts from a real sign-in. Only that branch clears — a session that reads back fine, or one belonging to the wrong account, is left alone.

## Testing

Both were exercised against the real account this was written for: `--manual-login` now reaches a sign-in form, the login sticks, and the identity is captured (`Logged in as @bendavidsteel (uid 7109148062094033926)`).

Four stubbed paths: settles on read 3 → confirmed, nothing cleared; readable immediately → one read, no retry cost; genuinely dead → raises after 5 reads and clears; wrong uid → refused with the good session intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)