### PR TITLE
Give profile pages the configured load timeout, not a fixed 10s

### DIFF
--- a/pytok/accounts/worker.py
+++ b/pytok/accounts/worker.py
@@ -61,6 +61,12 @@ ROTATE_EXCEPTIONS = (
 DEFAULT_TASKS_PER_REST = None  # None => never force a rest on task count
 REST_MINUTES = 5
 RATE_LIMIT_MINUTES = 15
+# Consecutive in-place session rebuilds (counted across tasks, not within one) before
+# the generic handler gives up on rebuilding and rotates instead. Rebuilding in place
+# is the right first move for a dead tab, but a fault that outlives the rebuild -- a
+# page that will not finish loading for this session -- otherwise repeats it on every
+# handle forever, pinning the worker to one account.
+MAX_INPLACE_REBUILDS = 3
 
 
 class Worker:
@@ -92,6 +98,9 @@ class Worker:
         self.tasks_done: int = 0
         self.api = None  # PyTok, built lazily and reused across tasks
         self._initialized = False
+        # Spans tasks: a session whose fault survives the rebuild fails the next handle
+        # the same way, so counting only within one task would never reach the limit.
+        self._inplace_rebuilds: int = 0
 
     def _acct_name(self) -> str:
         return self.current_account.username if self.current_account else "<none>"
@@ -208,6 +217,7 @@ class Worker:
                 result = await task(api)
                 await self.pool.increment_scrape_count(self.current_account.username)
                 self.tasks_done += 1
+                self._inplace_rebuilds = 0
                 return result
 
             except NoAccountError:
@@ -248,16 +258,32 @@ class Worker:
                 # Unknown error / browser crash / transient session failure.
                 # Drop the (probably dead) session and rebuild IN PLACE on the
                 # same account — these recover on a fresh session in seconds.
-                # We deliberately do NOT rotate+cooldown here: with a small pool
-                # (e.g. 2 accounts) rotating just locks this account for minutes
-                # and waits on the other busy one, turning a transient blip into
-                # a multi-minute stall. Genuine rate-limit/captcha/timeout still
-                # rotate via ROTATE_EXCEPTIONS above; a persistently unbuildable
-                # account is caught by _ensure_session's max_build_attempts.
+                # Rotating on the first one instead would, with a small pool (e.g. 2
+                # accounts), lock this account for minutes and wait on the other busy
+                # one, turning a transient blip into a multi-minute stall.
+                #
+                # But only up to MAX_INPLACE_REBUILDS: a fault that survives the
+                # rebuild is not the tab, and repeating the rebuild then fails every
+                # subsequent handle on this worker. _ensure_session's
+                # max_build_attempts does not cover that case — the session builds
+                # fine, it is the page that never loads.
                 last_exc = e
-                logger.error(f"Worker {self.id}: unexpected error on "
-                             f"{self._acct_name()}: {e!r}; rebuilding session in place")
-                await self._close_session()
+                self._inplace_rebuilds += 1
+                if self._inplace_rebuilds >= MAX_INPLACE_REBUILDS:
+                    # Rebuilding has stopped helping, so the fault is not the tab.
+                    # Rotate: a different account (and a cooldown for this one) is the
+                    # only lever left, and it stops this worker burning every handle.
+                    logger.error(f"Worker {self.id}: unexpected error on "
+                                 f"{self._acct_name()}: {e!r}; "
+                                 f"{self._inplace_rebuilds} in-place rebuilds did not "
+                                 f"help, cooldown {REST_MINUTES}m + rotate")
+                    self._inplace_rebuilds = 0
+                    await self.rotate_account(REST_MINUTES)
+                else:
+                    logger.error(f"Worker {self.id}: unexpected error on "
+                                 f"{self._acct_name()}: {e!r}; rebuilding session in "
+                                 f"place ({self._inplace_rebuilds}/{MAX_INPLACE_REBUILDS})")
+                    await self._close_session()
 
         raise RuntimeError(
             f"Worker {self.id}: task failed after {self.max_retries} attempts"

--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -73,6 +73,29 @@ class Base:
         except Exception:
             return False
 
+    async def _wait_for_page_load(self, page, what):
+        """Wait for the current navigation to reach readyState 'complete'.
+
+        Honours PyTok's page_load_timeout rather than imposing a ceiling of its own: a
+        profile page reaches 'interactive' seconds before 'complete', so a ceiling
+        shorter than the real load time throws away pages whose embedded data tag is
+        already there and parseable.
+
+        Raises pytok's TimeoutException rather than letting the bare TimeoutError out.
+        That one stringifies to '', which tells a log reader nothing, and being an
+        unrecognised type it lands in the accounts pool's generic handler, which
+        rebuilds the session in place on the same account -- no use when the page is
+        merely slow, and it repeats for every handle.
+        """
+        timeout = getattr(self.parent, '_page_load_timeout', 45)
+        try:
+            async with asyncio.timeout(timeout):
+                await page.wait_for_ready_state(until='complete', timeout=timeout + 1)
+        except (asyncio.TimeoutError, TimeoutError) as ex:
+            raise exceptions.TimeoutException(
+                f"{what} did not reach readyState 'complete' within {timeout}s"
+            ) from ex
+
     async def _is_captcha_visible(self):
         """Check if any captcha text is visible."""
         for text in CAPTCHA_TEXTS:
@@ -278,12 +301,20 @@ class Base:
             await asyncio.sleep(2)
 
         await page.send(cdp.page.navigate(current_url))
-        await asyncio.sleep(3)
 
-        if await self._is_selector_visible(content_tag):
-            return await self._find_element_by_selector(content_tag, timeout=1)
-        else:
-            raise exceptions.TimeoutException("Content did not become visible in time")
+        # Poll for the content instead of reading once after a fixed sleep. A page's
+        # embedded data tag and its content grid land seconds apart, and for the first
+        # few seconds get_content() returns a half-built document with no tag at all --
+        # so a caller that returns here on a short sleep hands back a page whose data
+        # the caller then fails to parse, reported as if the page had no data.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + getattr(self.parent, '_page_load_timeout', 45)
+        while loop.time() < deadline:
+            if await self._is_selector_visible(content_tag):
+                return await self._find_element_by_selector(content_tag, timeout=1)
+            await asyncio.sleep(1)
+
+        raise exceptions.TimeoutException("Content did not become visible in time")
 
     async def check_for_unavailable_or_captcha(self, unavailable_text):
         page = self.parent._page

--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -6,6 +6,7 @@ import random
 from zendriver import cdp
 
 from .. import exceptions, captcha_solver
+from ..helpers import extract_tag_contents
 
 TOK_DELAY = 20
 CAPTCHA_DELAY = 999999
@@ -73,28 +74,58 @@ class Base:
         except Exception:
             return False
 
-    async def _wait_for_page_load(self, page, what):
+    async def _wait_for_page_load(self, page, what, required=True):
         """Wait for the current navigation to reach readyState 'complete'.
 
-        Honours PyTok's page_load_timeout rather than imposing a ceiling of its own: a
-        profile page reaches 'interactive' seconds before 'complete', so a ceiling
-        shorter than the real load time throws away pages whose embedded data tag is
-        already there and parseable.
+        Honours PyTok's page_load_timeout rather than imposing a ceiling of its own.
 
-        Raises pytok's TimeoutException rather than letting the bare TimeoutError out.
-        That one stringifies to '', which tells a log reader nothing, and being an
-        unrecognised type it lands in the accounts pool's generic handler, which
-        rebuilds the session in place on the same account -- no use when the page is
-        merely slow, and it repeats for every handle.
+        `required=False` downgrades a timeout to a warning, for callers that follow this
+        with a stronger readiness gate of their own (waiting for the content grid, say).
+        'complete' waits on every image, video and beacon the page pulls in, so on a
+        heavy profile it lands tens of seconds after the content is usable, or not at
+        all -- failing there would throw away a page the caller could have scraped.
+
+        When it does raise, it raises pytok's TimeoutException rather than letting the
+        bare TimeoutError out. That one stringifies to '', which tells a log reader
+        nothing, and being an unrecognised type it lands in the accounts pool's generic
+        handler, which rebuilds the session in place on the same account -- no use when
+        the page is merely slow, and it repeats for every handle.
         """
         timeout = getattr(self.parent, '_page_load_timeout', 45)
         try:
             async with asyncio.timeout(timeout):
                 await page.wait_for_ready_state(until='complete', timeout=timeout + 1)
         except (asyncio.TimeoutError, TimeoutError) as ex:
-            raise exceptions.TimeoutException(
-                f"{what} did not reach readyState 'complete' within {timeout}s"
-            ) from ex
+            msg = f"{what} did not reach readyState 'complete' within {timeout}s"
+            if required:
+                raise exceptions.TimeoutException(msg) from ex
+            self.parent.logger.warning(f"{msg}; carrying on to wait for content")
+
+    async def _wait_for_data_tag(self, page, what):
+        """Wait until the page's embedded data tag is present and parseable.
+
+        The right readiness gate for anything that reads the rehydration JSON. The tag
+        lands early in the load, whereas readyState 'complete' can be tens of seconds
+        later on a heavy profile -- so gating on 'complete' fails pages whose data has
+        been sitting in the document the whole time. Polls rather than sleeping a fixed
+        interval, because for the first moments after a navigation get_content() returns
+        a half-built document with no tag in it at all.
+        """
+        timeout = getattr(self.parent, '_page_load_timeout', 45)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            try:
+                html = await page.get_content()
+                if html and extract_tag_contents(html):
+                    return
+            except Exception:
+                pass
+            await asyncio.sleep(0.5)
+
+        raise exceptions.TimeoutException(
+            f"{what}: embedded data tag did not appear within {timeout}s"
+        )
 
     async def _is_captcha_visible(self):
         """Check if any captcha text is visible."""

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -170,8 +170,7 @@ class User(Base):
         self.parent.logger.debug(f"Loading page: {url}")
         await page.send(cdp.page.navigate(url))
         self.parent.logger.debug(f"Navigate sent, waiting for ready state")
-        async with asyncio.timeout(10):
-            await page.wait_for_ready_state(until='complete', timeout=11)
+        await self._wait_for_page_load(page, f"@{self.username}")
         await asyncio.sleep(3)  # Brief wait for dynamic content
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
@@ -453,8 +452,7 @@ class User(Base):
         self.parent.logger.debug(f"Loading page: {url}")
         await page.send(cdp.page.navigate(url))
         self.parent.logger.debug(f"Navigate sent, waiting for ready state")
-        async with asyncio.timeout(30):
-            await page.wait_for_ready_state(until='complete', timeout=31)
+        await self._wait_for_page_load(page, f"@{self.username}")
         await asyncio.sleep(3)  # Brief wait for dynamic content
         self.parent.logger.debug(f"Page loaded for scraping videos")
 

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -169,9 +169,11 @@ class User(Base):
 
         self.parent.logger.debug(f"Loading page: {url}")
         await page.send(cdp.page.navigate(url))
-        self.parent.logger.debug(f"Navigate sent, waiting for ready state")
-        await self._wait_for_page_load(page, f"@{self.username}")
-        await asyncio.sleep(3)  # Brief wait for dynamic content
+        self.parent.logger.debug(f"Navigate sent, waiting for the embedded data tag")
+        # This method reads the rehydration JSON, so wait for that rather than for
+        # readyState 'complete' -- the tag is parseable long before the page finishes
+        # pulling in its media, and on a heavy profile 'complete' may never arrive.
+        await self._wait_for_data_tag(page, f"@{self.username}")
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
         await self.wait_for_content_or_unavailable_or_captcha(
@@ -452,7 +454,10 @@ class User(Base):
         self.parent.logger.debug(f"Loading page: {url}")
         await page.send(cdp.page.navigate(url))
         self.parent.logger.debug(f"Navigate sent, waiting for ready state")
-        await self._wait_for_page_load(page, f"@{self.username}")
+        # Not fatal if 'complete' never lands: the wait for the video grid below is the
+        # real readiness gate, and a profile heavy enough to never finish loading is
+        # still perfectly scrapeable once its grid is up.
+        await self._wait_for_page_load(page, f"@{self.username}", required=False)
         await asyncio.sleep(3)  # Brief wait for dynamic content
         self.parent.logger.debug(f"Page loaded for scraping videos")
 


### PR DESCRIPTION
## What

Fixes how the scraping path waits on profile pages. Four related changes:

1. **`Base._wait_for_page_load`** honours PyTok's `page_load_timeout` instead of a ceiling of its own, and raises pytok's `TimeoutException` naming the handle and the timeout. Replaces `asyncio.timeout(10)` in `_info_full_scrape` and `asyncio.timeout(30)` in `_get_videos_scraping`. It also takes `required=False`, which downgrades a timeout to a warning for callers that follow it with a stronger gate.
2. **`_info_full_scrape` gates on the embedded data tag**, not on `readyState complete` — `Base._wait_for_data_tag` polls until the rehydration JSON parses. This also removes the fixed `sleep(3)` that followed it.
3. **The recovery path** in `wait_for_content_or_unavailable_or_captcha` polls for the content selector instead of reading once after a fixed `sleep(3)`.
4. **The generic handler** in `Worker.execute_task` escalates to rotate after `MAX_INPLACE_REBUILDS` (3) consecutive in-place rebuilds, counted across tasks and reset on success.

## Why

Timed on the edge worker against a seed handle the crawler had been failing:

| t | readyState | embedded data tag | grid anchors |
|---|---|---|---|
| 2.1s | loading | absent, html empty | 0 |
| 4.0s | loading | **present, parses** | 0 |
| 10.1s | **interactive** | present, 266,876 chars | 0 |
| **14.1s** | **complete** | present | 19 |

`_info_full_scrape` allowed **10s**, landing in the gap between `interactive` and `complete` — discarding a page whose data had been parseable for six seconds. `page_load_timeout` already existed and was set to 45s by the crawler; profile pages ignored it.

The knock-on was the expensive part. `asyncio.timeout` raises a bare `TimeoutError`, which stringifies to `''` (so the log read `unexpected error on <account>: TimeoutError()`) and matches neither `DATA_LEVEL_EXCEPTIONS` nor `ROTATE_EXCEPTIONS`, so it fell into the generic handler, which rebuilds the session **in place on the same account**. Rebuilding cannot fix a slow page, so the next handle failed identically: one worker logged **35 rebuilds and 13 consecutively failed handles over 25 minutes** without rotating, while the other completed 1 handle.

**Raising the ceiling alone was not enough.** Re-timed, the same profile reached `complete` in 20s on one attempt and not within 45s on the next — `complete` waits on every image, video and beacon the page pulls in, so on a large profile it is effectively unbounded and any fixed ceiling just moves where it fails. Hence (2): wait for the thing the method actually reads. Telling detail from that run — after `info_full` timed out, the listing walk went on to yield every video requested, i.e. the user-info step was failing handles the walk could scrape.

(3) is the same read-too-early bug one layer down: for the first moments after a navigation `get_content()` returns a half-built document with no tag, so returning after a fixed 3s sleep handed the caller a page it then failed to parse. That surfaced as `NotAvailableException('Could not find the tag contents')`, which reads like the page had no data rather than like we read it too early — and it cost real time diagnosing an account as blocked when it was fine.

## Verification

End-to-end on the worker, same account, before/after:

| handle | before | after |
|---|---|---|
| `officialpaulbarron` (failed 3× in production) | `TimeoutError()` at ~12s | **`info_full` 7.3s, 80/80 videos** |
| `therock` (control) | ok, ~9.4s | **`info_full` 7.7s, 64/64 videos** |

Faster as well as more reliable, since it no longer waits for `complete` or the fixed `sleep(3)`.

10 functional checks, stubbing only the browser/pool primitives so the real `_wait_for_page_load` and the real `execute_task` taxonomy run:

```
PASS: slow page raises pytok TimeoutException
PASS: message is not empty  msg="@someone did not reach readyState 'complete' within 2s"
PASS: message names the handle and timeout
PASS: honours configured page_load_timeout (~2s)  elapsed=2.0s
PASS: fast page does not raise
PASS: missing _page_load_timeout falls back to default
PASS: failing task still raises
PASS: escalates to rotate after MAX_INPLACE_REBUILDS  events=['rebuild', 'rebuild', 'rotate:5']
PASS: counter persists across tasks (not reset per task)
PASS: a success resets the rebuild counter
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)