### PR TITLE
Read the user's details from XHR when the page is client-rendered

### DIFF
--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -101,20 +101,27 @@ class Base:
                 raise exceptions.TimeoutException(msg) from ex
             self.parent.logger.warning(f"{msg}; carrying on to wait for content")
 
-    async def _wait_for_data_tag(self, page, what):
-        """Wait until the page's embedded data tag is present and parseable.
+    async def _wait_for_page_data(self, page, what, fallback=None):
+        """Wait until the page's data is readable.
 
-        The right readiness gate for anything that reads the rehydration JSON. The tag
-        lands early in the load, whereas readyState 'complete' can be tens of seconds
-        later on a heavy profile -- so gating on 'complete' fails pages whose data has
-        been sitting in the document the whole time. Polls rather than sleeping a fixed
-        interval, because for the first moments after a navigation get_content() returns
-        a half-built document with no tag in it at all.
+        Usually that means the embedded data tag. It lands early in the load, whereas
+        readyState 'complete' can be tens of seconds later on a heavy page -- so gating
+        on 'complete' fails pages whose data has been sitting in the document the whole
+        time. Polls rather than sleeping a fixed interval, because for the first moments
+        after a navigation get_content() returns a half-built document with no tag in it.
+
+        `fallback` is an optional coroutine for callers whose data can arrive by another
+        route: TikTok also serves these pages client-rendered, as a shell whose script
+        fetches the data over XHR and leaves nothing embedded to parse. It is polled
+        alongside the tag, and ending the wait on whichever appears first means a
+        client-rendered page costs no more than a server-rendered one.
         """
         timeout = getattr(self.parent, '_page_load_timeout', 45)
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while loop.time() < deadline:
+            if fallback is not None and await fallback():
+                return
             try:
                 html = await page.get_content()
                 if html and extract_tag_contents(html):
@@ -124,7 +131,7 @@ class Base:
             await asyncio.sleep(0.5)
 
         raise exceptions.TimeoutException(
-            f"{what}: embedded data tag did not appear within {timeout}s"
+            f"{what}: no page data appeared within {timeout}s"
         )
 
     async def _is_captcha_visible(self):

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -547,7 +547,14 @@ class User(Base):
         has_more = True
 
         html = await page.get_content()
-        tag_contents = extract_tag_contents(html)
+        try:
+            tag_contents = extract_tag_contents(html)
+        except NotAvailableException:
+            # A client-rendered page embeds nothing, so there is no first page to read
+            # here -- but the scroll below works off the item_list responses the page
+            # fetches for itself, which arrive either way. has_more stays True so we go
+            # straight there rather than reporting the profile as unavailable.
+            tag_contents = None
 
         if tag_contents:
             data = json.loads(tag_contents)
@@ -651,7 +658,13 @@ class User(Base):
         if len(video_responses) == 0:
             # Check HTML data for status codes before failing
             html = await self.parent._page.get_content()
-            tag_contents = extract_tag_contents(html)
+            try:
+                tag_contents = extract_tag_contents(html)
+            except NotAvailableException:
+                # Best-effort status check only; a client-rendered page has no embedded
+                # JSON to check. Fall through to ApiFailedException, which retries and
+                # falls back, rather than letting "no tag" surface as "no such account".
+                tag_contents = None
             if tag_contents:
                 data = json.loads(tag_contents)
                 if '__DEFAULT_SCOPE__' in data:

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -65,6 +65,9 @@ class User(Base):
         self.parent = parent
         self.__update_id_sec_uid_username(user_id, sec_uid, username)
         self._used_api_for_info = False
+        # the webapp's own api/user/detail response, when the page was client-rendered
+        # and left nothing embedded to parse (see _harvest_user_detail_xhr)
+        self._xhr_user_detail: Optional[dict] = None
         if data is not None:
             self.as_dict = data
             self.__extract_from_data()
@@ -162,6 +165,57 @@ class User(Base):
         self._used_api_for_info = True
         return resp
 
+    @staticmethod
+    def _user_from_user_detail(data) -> Optional[dict]:
+        """Pull the user out of an api/user/detail payload.
+
+        The rehydration tag's webapp.user-detail scope carries the same shape, so both
+        delivery routes parse through here.
+        """
+        if not isinstance(data, dict) or data.get('statusCode', 0) != 0:
+            return None
+        user_info = data.get('userInfo', {})
+        user = user_info.get('user', {})
+        if not user or not user.get('id'):
+            return None
+        return {**user, **user_info.get('stats', {})}
+
+    async def _harvest_user_detail_xhr(self) -> bool:
+        """Bank the webapp's own api/user/detail response, if it made one.
+
+        A server-rendered page never requests that endpoint — its details are already
+        embedded — so this only ever finds anything on a client-rendered one, where the
+        captured response is the *only* copy of the user's details in existence.
+
+        Reading the capture drains it, hence stashing the first hit: the caller polls
+        this, and the response must survive until the parse.
+        """
+        if self._xhr_user_detail is not None:
+            return True
+        try:
+            responses = await self.parent.process_pending_responses('api/user/detail')
+        except Exception:
+            return False
+        for resp in responses or []:
+            body = resp.get('body') or ''
+            if not body:
+                continue
+            try:
+                data = json.loads(body) if isinstance(body, str) else body
+            except Exception:
+                continue
+            user = self._user_from_user_detail(data)
+            if not user:
+                continue
+            # the page may have fetched details for other users too (sidebars, suggested
+            # accounts), so don't accept one that isn't the profile we asked for
+            unique_id = user.get('uniqueId')
+            if unique_id and unique_id.lower() != self.username.lower():
+                continue
+            self._xhr_user_detail = user
+            return True
+        return False
+
     async def _info_full_scrape(self, **kwargs) -> dict:
         url = f"https://www.tiktok.com/@{self.username}"
 
@@ -169,11 +223,14 @@ class User(Base):
 
         self.parent.logger.debug(f"Loading page: {url}")
         await page.send(cdp.page.navigate(url))
-        self.parent.logger.debug(f"Navigate sent, waiting for the embedded data tag")
-        # This method reads the rehydration JSON, so wait for that rather than for
-        # readyState 'complete' -- the tag is parseable long before the page finishes
-        # pulling in its media, and on a heavy profile 'complete' may never arrive.
-        await self._wait_for_data_tag(page, f"@{self.username}")
+        self.parent.logger.debug(f"Navigate sent, waiting for the profile's data")
+        # Wait for the data rather than for readyState 'complete': the tag is parseable
+        # long before the page finishes pulling in its media, and on a heavy profile
+        # 'complete' may never arrive. Either delivery route ends the wait -- embedded in
+        # the tag, or fetched by the page from api/user/detail.
+        self._xhr_user_detail = None
+        await self._wait_for_page_data(page, f"@{self.username}",
+                                       fallback=self._harvest_user_detail_xhr)
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
         await self.wait_for_content_or_unavailable_or_captcha(
@@ -182,32 +239,45 @@ class User(Base):
             no_content_text=["No content", "This account is private", "Log in to TikTok"]
         )
 
+        user = None
+
         # Get user info from page HTML (like the working example)
         html_body = await page.get_content()
-        tag_contents = extract_tag_contents(html_body)
+        try:
+            tag_contents = extract_tag_contents(html_body)
+        except NotAvailableException:
+            # No embedded payload at all, which is a client-rendered page rather than a
+            # missing account -- the XHR route below is where its details are. Letting
+            # this out would report the profile as unavailable, which the accounts pool
+            # treats as data-level and skips the handle for good.
+            tag_contents = None
 
-        if not tag_contents:
-            raise InvalidJSONException("Could not find data script tag in page")
+        if tag_contents:
+            self.initial_json = json.loads(tag_contents)
 
-        self.initial_json = json.loads(tag_contents)
+            # Try different JSON structures TikTok uses (matching the working example)
+            if '__DEFAULT_SCOPE__' in self.initial_json:
+                user = self._user_from_user_detail(
+                    self.initial_json['__DEFAULT_SCOPE__'].get('webapp.user-detail', {})
+                )
 
-        user = None
-        sec_uid = None
+            if 'UserModule' in self.initial_json and user is None:
+                users = self.initial_json['UserModule'].get('users', {})
+                stats = self.initial_json['UserModule'].get('stats', {})
+                if self.username in users:
+                    user = {**users[self.username], **stats.get(self.username, {})}
 
-        # Try different JSON structures TikTok uses (matching the working example)
-        if '__DEFAULT_SCOPE__' in self.initial_json:
-            user_detail = self.initial_json['__DEFAULT_SCOPE__'].get('webapp.user-detail', {})
-            if user_detail.get('statusCode') == 0:
-                user_info = user_detail.get('userInfo', {})
-                user = {**user_info.get('user', {}), **user_info.get('stats', {})}
-                sec_uid = user_info.get('user', {}).get('secUid')
-
-        if 'UserModule' in self.initial_json and user is None:
-            users = self.initial_json['UserModule'].get('users', {})
-            stats = self.initial_json['UserModule'].get('stats', {})
-            if self.username in users:
-                user = {**users[self.username], **stats.get(self.username, {})}
-                sec_uid = user.get('secUid')
+        if user is None:
+            # Client-rendered: nothing embedded to parse, so use what the page fetched
+            # for itself. Re-harvest first — the response may only have landed while we
+            # were waiting on the video grid above.
+            await self._harvest_user_detail_xhr()
+            user = self._xhr_user_detail
+            if user is not None:
+                self.parent.logger.debug(
+                    f"@{self.username}: page carried no embedded data, took the user's "
+                    f"details from its own api/user/detail response"
+                )
 
         if user is None:
             raise InvalidJSONException("Failed to find user data in HTML")


### PR DESCRIPTION
## What

Teaches the scraping path that TikTok serves the profile page **two** ways, not one:

- **Server-rendered** — the user's details arrive embedded in `__UNIVERSAL_DATA_FOR_REHYDRATION__`.
- **Client-rendered** — the page is a shell with nothing embedded, and its own script fetches the details from `api/user/detail`.

`_info_full_scrape` only knew the first. On a client-rendered page `extract_tag_contents` raised `NotAvailableException`, which the accounts pool classifies as **data-level** — so the handle was skipped for good and the account looked blocked.

The response is already banked by PyTok's CDP capture, so no extra fetch is needed:

- `_wait_for_page_data` (was `_wait_for_data_tag`) takes an optional `fallback` coroutine polled alongside the tag, so a client-rendered page ends the wait as soon as its XHR lands instead of burning the whole timeout.
- `_harvest_user_detail_xhr` banks the captured `api/user/detail` response, keeping the first hit because reading the capture drains it. It ignores responses for *other* users, which the page also fetches for sidebars and suggested accounts.
- `_info_full_scrape` treats a missing tag as "try the other route", and parses both routes through one `_user_from_user_detail` helper — the embedded `webapp.user-detail` scope and the XHR payload share a shape.
- Two more unguarded tag reads in the walk are handled: `_get_videos_scraping` (the tag is only its *first* page; the scroll that follows works off `api/post/item_list`, which arrives either way) and `_get_initial_videos` (a best-effort status check, where letting `NotAvailableException` out swapped a retryable failure for a permanent one).

## Why

Traced on one pooled account against a profile that another account served server-rendered minutes earlier:

| | server-rendered | client-rendered |
|---|---|---|
| embedded payload | present | **none — 0 chars** |
| served HTML | ~620 KB | **149 KB (shell)** |
| `api/user/detail` XHR | **never requested** | **requested ×1** |
| `api/post/item_list` XHR | ×1, 912,739 bytes, 32 videos | ×4, 480,447 bytes, 16 videos |
| DOM rendered | 32 grid items | 16 grid items |

A server-rendered page never asks for `api/user/detail` — it does not need to. That request is the fingerprint of the client-rendered variant.

Corroborated by the crawler's own logs: the param-template cache is filled *only* from requests the webapp itself issues, and `No param template captured yet for 'api/user/detail'` fired on **100% of handles** across every run (1014/1014, 216/216) — so across thousands of page loads on the server-rendered path the webapp never once issued it. A client-rendered page issues it immediately.

Note the video grid arrives over XHR on **both** variants, so only user info was ever affected — which is why the failure cascaded: `_get_initial_videos` filters captured responses on `secUid`, and `sec_uid` comes from user info.

## Verification

Live on the edge worker, the account that had been failing every handle:

| | before | after |
|---|---|---|
| client-rendered account | `Could not find the tag contents`, **0 videos** | **`info_full` OK, 64/64 videos, WORKING** |
| server-rendered control | 64/64 videos | **64/64 videos** (unchanged) |

The client-rendered path is slower (`info_full` 30.2s vs 9.8s; first video at 50.6s vs 0.0s) since nothing is pre-baked — but it collects.

12 functional checks, stubbing only the page and the response capture so the real `_info_full_scrape`, `_wait_for_page_data`, `_harvest_user_detail_xhr` and `__extract_from_data` all run:

```
PASS: client-rendered page yields the user
PASS: got the right user  therock
PASS: stats merged in
PASS: sec_uid set (the listing walk filters on it)  sec_uid='SEC-UID-XYZ'
PASS: user_id set  user_id='123'
PASS: server-rendered page still parses
PASS: server-rendered sec_uid set
PASS: did not need the XHR route
PASS: another user's details are rejected
PASS: no data anywhere -> raises
PASS: harvest survives the capture being drained
PASS: stashed user retained
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)