### PR TITLE
Keep the first page's listing response instead of discarding it

### DIFF
--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -120,6 +120,11 @@ class Base:
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
         while loop.time() < deadline:
+            # A response body only lives in Chrome until it decides to drop it, so bank
+            # them as they finish rather than at the end of the wait: the listing the page
+            # fetches on load is often the only copy there is, and this wait can run for
+            # tens of seconds beside it.
+            await self.parent.collect_pending_response_bodies()
             if fallback is not None and await fallback():
                 return
             try:

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -238,6 +238,10 @@ class User(Base):
             "Couldn't find this account",
             no_content_text=["No content", "This account is private", "Log in to TikTok"]
         )
+        # The grid's own listing response has landed by now, and nothing reads it until the
+        # caller asks for videos -- which may be a captcha solve and a page of work away.
+        # Bank it here so it is ours rather than Chrome's for that whole gap.
+        await self.parent.collect_pending_response_bodies()
 
         user = None
 
@@ -531,8 +535,11 @@ class User(Base):
         await asyncio.sleep(3)  # Brief wait for dynamic content
         self.parent.logger.debug(f"Page loaded for scraping videos")
 
-        # Process any pending responses
-        await self.parent.process_pending_responses()
+        # Bank what the page has fetched so far. Draining it instead would throw away this
+        # page's own listing response, which on a profile whose grid fits in one page is
+        # the only one there will ever be -- nothing further is lazy-loaded for the scroll
+        # below to pick up.
+        await self.parent.collect_pending_response_bodies()
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
         await self.wait_for_content_or_unavailable_or_captcha(
@@ -540,6 +547,7 @@ class User(Base):
             "Couldn't find this account",
             no_content_text=["No content", "This account is private", "Log in to TikTok"]
         )
+        await self.parent.collect_pending_response_bodies()
 
         # Get initial videos from page HTML (like the working example)
         videos = []


### PR DESCRIPTION
Fixes #41 (the size-bound half of it — see *Scope* below).

## The premise the issue rests on no longer holds

The issue and its follow-up both assume the grid JSON is somewhere in the page and the embedded-JSON parse is just missing it. It isn't there any more.

Checking the live `__UNIVERSAL_DATA_FOR_REHYDRATION__` for the three handles named in the issue (`@georges.duhamel.g`, `@ron_filipkowski_`, `@thisisbillgates`), `__DEFAULT_SCOPE__` carries `webapp.user-detail` but **no `webapp.user-post` at all**, and the string `webapp.user-post` does not appear anywhere in the served HTML. TikTok fetches the grid client-side now, at every catalogue size.

So there is no richer embedded source to parse harder for. The `api/post/item_list` response PyTok captures over CDP is the only copy of the listing that exists — which makes *preserving* it the whole problem, and rules out the "parse the JSON that must be in the HTML" framing.

## What was actually breaking

`_get_videos_scraping` was destroying it. After navigating, it called `process_pending_responses()` with no pattern and dropped the result:

```python
# Process any pending responses
await self.parent.process_pending_responses()
```

That reads as "flush what the previous page left behind", but it also drains the listing response the *new* page had just fetched. On a profile with more posts the scroll that follows re-requests and recovers. On one whose grid fits in a single page nothing further is lazy-loaded, so there was nothing left to recover from — exactly the `rounds the page asked for nothing 16` signature, and exactly why short catalogues failed terminally while large ones self-healed.

Separately, bodies live in Chrome only until it drops them, and a request id dies with its page. Between the grid rendering and the caller asking for videos sits a captcha solve and a page of unrelated work. I hit the eviction directly while reproducing: `ProtocolException: No resource with given identifier found` on `Network.getResponseBody`.

## The change

Bank bodies rather than drain them, and bank them earlier. `collect_pending_response_bodies()` consumes nothing, so later filtered reads still find everything.

- **`_get_videos_scraping`** swaps the discarding drain for `collect_pending_response_bodies()`. The scroll walk's first round reads `api/post/item_list` out of the collected responses, so the first page is recovered with no new parsing code.
- **`_info_full_scrape`** banks once the grid is up, closing the gap until the caller asks for videos.
- **`_wait_for_page_data`** banks on each poll, covering the load window itself.

No DOM parsing, and no per-id `video.info()` refetching — the concern that made the originally-suggested fallback unattractive does not arise.

## Verification

Run against the pool on the crawler box.

Before, `@georges.duhamel.g` (1 post) failed repeatedly with `ApiFailedException: no videos returned ... though the profile reports 1`. After:

| handle | posts | result |
|---|---|---|
| `@georges.duhamel.g` | 1 | 3/3 walks succeeded |
| `@ron_filipkowski_` | 12 | 3/3 walks succeeded |
| `@thisisbillgates` | 12 | 3/3 walks succeeded |

`tests/test_user.py` (asserts ≥100 videos off a large catalogue) passes, so the scroll path is unregressed.

Two notes on the verification: it ran with these three edits applied on top of `feat/scroll-walk-driver`, since that is what the crawler box had checked out and its counters are what make the failure legible. The change itself touches nothing from that branch and applies cleanly to `master`, which is what this PR is based on. One run also yielded 2 videos for `@georges.duhamel.g` against `videoCount=1` — not from this change, which adds no sources and still filters `api/post/item_list` by `secUid`; most likely a stale `videoCount` or a repost served in that listing.

## Scope

This addresses the size-bound failure — the 8 walks in the follow-up's table where no `item_list` XHR ever fired.

It does **not** address the larger group (16 walks, all grid sizes) where the page *did* request and TikTok answered with an empty 200. That is a block on the signed request itself, and no amount of banking recovers a body that was never sent. The in-session retry and DOM-grid fallback discussed on the issue are what would blunt that one; leaving them out for now keeps this change small and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
