### PR TITLE
Drive the scroll walks from one policy, off the element API

### DIFF
--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -180,7 +180,10 @@ class ScrollWalk:
         self.rounds_done = 0
         self.loop_seconds = 0.0
         self.feed_items = 0
-        self.reason = 'ran out of scrolls'
+        # Holds unless the walk ends on its own terms, which covers the caller closing the
+        # generator -- a date window it has walked past, a session it has given up on. Do
+        # not let that read as a budget we exhausted.
+        self.reason = 'the caller stopped reading the walk'
         # True only when the feed itself said nothing follows. Every other way of stopping
         # is a walk that was cut off, which callers must not mistake for a complete one.
         self.listing_ended = False
@@ -245,6 +248,8 @@ class ScrollWalk:
                     stall_rounds >= SCROLL_STALL_ROUNDS and stalled_for >= SCROLL_STALL_SECONDS):
                 self.reason = f'nothing new for {stalled_for:.0f}s over {stall_rounds} rounds'
                 return
+
+        self.reason = f'ran out of scrolls ({self.max_rounds})'
 
     def summary(self):
         parts = [f"{self.rounds_done} scrolls in {self.loop_seconds:.0f}s"]

--- a/pytok/api/base.py
+++ b/pytok/api/base.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import Counter
 from datetime import datetime
 import json
 import random
@@ -10,6 +11,28 @@ from ..helpers import extract_tag_contents
 
 TOK_DELAY = 20
 CAPTCHA_DELAY = 999999
+
+# --- infinite-scroll feeds ---------------------------------------------------
+# How long one round waits for the listing response its scroll asked for. A healthy
+# response lands in well under a second; this only bounds a slow or blocked one.
+SCROLL_RESPONSE_TIMEOUT = 8
+SCROLL_POLL_INTERVAL = 0.2
+# How long to allow for the request itself to appear. Past this, a round in which the page
+# has asked for nothing is not slow, it is stalled, and the remaining timeout would be spent
+# waiting for a response nothing is going to send.
+SCROLL_SILENT_GRACE = 1.5
+# Floor per round, so a fast feed is paged at something like a human reading speed
+# rather than as fast as the network allows.
+SCROLL_MIN_ROUND = 0.6
+SCROLL_ROUND_JITTER = 0.4
+# A feed is only declared finished after this much loop-owned time with nothing new, and
+# this many rounds. Both, because a page under load can take several rounds to answer, and
+# giving up early is indistinguishable from reaching the end of a listing.
+SCROLL_STALL_SECONDS = 25
+SCROLL_STALL_ROUNDS = 5
+# ...but rounds that come back fast (a feed re-sending a page we already have) would take
+# far too many of them to fill the seconds above, so cap the rounds outright as well.
+SCROLL_STALL_MAX_ROUNDS = 20
 
 # Text patterns for detecting various page states
 CAPTCHA_TEXTS = [
@@ -24,8 +47,221 @@ LOGIN_CLOSE_TEXTS = [
     "Continue without login"
 ]
 
+# TikTok's "Something went wrong / Refresh" panel, which stops a feed paginating until it
+# is cleared. Shared between the scroll round below and check_and_resolve_refresh_button.
+_CLICK_REFRESH_JS_BODY = """
+  let refreshClicked = false;
+  for (const el of document.querySelectorAll('p,button,div[role=button]')) {
+    if (el.textContent && el.textContent.trim() === 'Refresh') {
+      (el.closest('button') || el).click();
+      refreshClicked = true;
+      break;
+    }
+  }
+"""
+
+_CLICK_REFRESH_JS = "(() => {%s  return refreshClicked;\n})()" % _CLICK_REFRESH_JS_BODY
+
+# One round trip that does everything a scroll round needs from the page: clear whatever
+# TikTok has put over the feed, scroll the element that actually scrolls, and report where
+# that got us.
+#
+# It deliberately goes through page.evaluate rather than zendriver's element API. select_all()
+# fetches the whole DOM tree over CDP and then walks that tree once per match, so its cost
+# grows with the square of the feed: on a grid of a thousand items a single 'is the Refresh
+# button there?' check costs seconds, and it was charged once per round -- which capped how
+# deep any walk could get before the loop was spending all its time on bookkeeping. The same
+# work in JS is a millisecond at any feed size.
+_SCROLL_FEED_JS = """
+(() => {
+  const itemSel = %(items)s;
+  const containerSel = %(container)s;
+
+  // Both of these sit over the feed and stop it paginating until dismissed.
+%(refresh)s
+  let loginClosed = false;
+  const close = document.querySelector('[data-e2e="modal-close-inner-button"]');
+  if (close) { close.click(); loginClosed = true; }
+
+  // Some feeds scroll an inner container instead of the document, and there scrolling the
+  // window is a no-op that never fires the pagination request. A caller that knows its
+  // container says so; otherwise only go looking when the document does not scroll at all,
+  // since a feed page has plenty of nested scrollable divs that are not the feed.
+  const docEl = document.scrollingElement || document.documentElement;
+  let el = containerSel ? document.querySelector(containerSel) : null;
+  if (!el && itemSel && docEl.scrollHeight <= docEl.clientHeight + 4) {
+    const item = document.querySelector(itemSel);
+    for (let p = item && item.parentElement; p; p = p.parentElement) {
+      const overflow = getComputedStyle(p).overflowY;
+      if (p.scrollHeight > p.clientHeight + 4 && (overflow === 'auto' || overflow === 'scroll')) {
+        el = p;
+        break;
+      }
+    }
+  }
+  const scrollsDocument = !el || el.scrollHeight <= el.clientHeight;
+  if (scrollsDocument) el = docEl;
+
+  const before = el.scrollTop;
+  if (scrollsDocument) {
+    window.scrollBy(0, window.innerHeight * 3);
+  } else {
+    el.scrollTop = el.scrollHeight;
+  }
+  return {
+    items: itemSel ? document.querySelectorAll(itemSel).length : 0,
+    moved: el.scrollTop - before,
+    atBottom: (el.scrollHeight - el.scrollTop - el.clientHeight) < 4,
+    refreshClicked: refreshClicked,
+    loginClosed: loginClosed,
+    scrollsDocument: scrollsDocument,
+  };
+})()
+"""
+
+# Pull back up a viewport and a half. Once the feed is pinned to its bottom, scrolling
+# down again is a no-op and the sentinel that triggers the next page cannot re-enter the
+# viewport, so no amount of further scrolling will ever load anything: the only way to
+# re-arm it is to leave and come back.
+_NUDGE_FEED_JS = """
+(() => {
+  const containerSel = %(container)s;
+  let el = containerSel ? document.querySelector(containerSel) : null;
+  if (!el || el.scrollHeight <= el.clientHeight) el = document.scrollingElement || document.documentElement;
+  el.scrollTop = Math.max(0, el.scrollTop - Math.round(el.clientHeight * 1.5));
+  return el.scrollTop;
+})()
+"""
+
+
+class ScrollRound:
+    """One round of an infinite-scroll feed, handed to the caller to interpret.
+
+    The caller sets `produced` to how many new items it got out of `responses`, since only
+    it knows what its endpoint's payload looks like and what counts as new, and `stop` when
+    the feed itself said the listing is over.
+    """
+
+    __slots__ = ('responses', 'state', 'requested', 'produced', 'stop')
+
+    def __init__(self, responses, state, requested):
+        self.responses = responses
+        # what the page reported about the scroll itself (see _SCROLL_FEED_JS)
+        self.state = state
+        # whether the page asked for another page at all this round
+        self.requested = requested
+        self.produced = 0
+        self.stop = False
+
+
+class ScrollWalk:
+    """Drives one infinite-scroll feed, and records how the walk went.
+
+    Owns what every feed here shares: pacing, clearing the panels TikTok puts over a feed,
+    waiting for the response a scroll asked for rather than sleeping a fixed interval,
+    nudging a feed that has stopped asking for pages, and deciding when a feed that
+    produces nothing is finished rather than merely slow.
+
+    Callers add their own tallies to `stats` and put `summary()` in their log line, so one
+    walk is one line saying how deep it got and which of the above happened.
+    """
+
+    def __init__(self, feed, url_pattern, item_selector=None, container_selector=None,
+                 max_rounds=30, before_round=None):
+        self.feed = feed
+        self.url_pattern = url_pattern
+        self.item_selector = item_selector
+        self.container_selector = container_selector
+        self.max_rounds = max_rounds
+        # optional coroutine run at the top of each round (a captcha check, say)
+        self.before_round = before_round
+
+        self.stats = Counter()
+        self.rounds_done = 0
+        self.loop_seconds = 0.0
+        self.feed_items = 0
+        self.reason = 'ran out of scrolls'
+        # True only when the feed itself said nothing follows. Every other way of stopping
+        # is a walk that was cut off, which callers must not mistake for a complete one.
+        self.listing_ended = False
+
+    async def rounds(self):
+        loop = asyncio.get_running_loop()
+        stalled_for = 0.0
+        stall_rounds = 0
+        next_round_at = 0.0
+
+        while self.rounds_done < self.max_rounds:
+            now = loop.time()
+            if now < next_round_at:
+                await asyncio.sleep(next_round_at - now)
+
+            round_started = loop.time()
+            if self.before_round is not None:
+                await self.before_round()
+
+            state = await self.feed.scroll_feed(self.item_selector, self.container_selector)
+            self.feed_items = state.get('items') or self.feed_items
+            if state.get('refreshClicked'):
+                self.stats['refresh_panels'] += 1
+            if state.get('loginClosed'):
+                self.stats['login_modals'] += 1
+
+            responses, requested = await self.feed.await_api_responses(self.url_pattern)
+            if not requested:
+                self.stats['rounds_the_page_asked_for_nothing'] += 1
+
+            # Timed before the caller sees the round, and the next round is scheduled from
+            # this one's start: a caller that works on each item as it arrives (downloading
+            # it, say) then pays the pacing out of time it was spending anyway, and cannot
+            # spend the stall budget below on our behalf.
+            round_seconds = loop.time() - round_started
+            self.loop_seconds += round_seconds
+            next_round_at = round_started + self.feed.scroll_round_floor()
+
+            rnd = ScrollRound(responses, state, requested)
+            yield rnd
+            self.rounds_done += 1
+
+            if rnd.stop:
+                self.listing_ended = True
+                self.reason = 'the feed said the listing ended'
+                return
+
+            if rnd.produced:
+                stalled_for = 0.0
+                stall_rounds = 0
+                continue
+
+            stall_rounds += 1
+            stalled_for += round_seconds
+            if not requested or state.get('atBottom') or not state.get('moved'):
+                # pinned to the bottom, or not scrolling at all, so scrolling down again
+                # cannot fire anything: back off so the next scroll can re-arm the feed
+                if await self.feed.nudge_feed(self.container_selector):
+                    self.stats['nudges'] += 1
+
+            if stall_rounds >= SCROLL_STALL_MAX_ROUNDS or (
+                    stall_rounds >= SCROLL_STALL_ROUNDS and stalled_for >= SCROLL_STALL_SECONDS):
+                self.reason = f'nothing new for {stalled_for:.0f}s over {stall_rounds} rounds'
+                return
+
+    def summary(self):
+        parts = [f"{self.rounds_done} scrolls in {self.loop_seconds:.0f}s"]
+        if self.item_selector:
+            parts.append(f"feed held {self.feed_items} items")
+        parts += [f"{name.replace('_', ' ')} {n}" for name, n in sorted(self.stats.items()) if n]
+        return ", ".join(parts) + f"; stopped: {self.reason}"
+
 
 class Base:
+
+    def scroll_walk(self, url_pattern, item_selector=None, container_selector=None,
+                    max_rounds=30, before_round=None):
+        """A ScrollWalk over this feed — see that class."""
+        return ScrollWalk(self, url_pattern, item_selector=item_selector,
+                          container_selector=container_selector, max_rounds=max_rounds,
+                          before_round=before_round)
 
     async def _find_element_by_selector(self, selector, timeout=5):
         """Find element by CSS selector, returns None if not found."""
@@ -219,16 +455,21 @@ class Base:
         return await self._find_element_by_selector(content_tag, timeout=1)
 
     async def check_and_resolve_refresh_button(self):
-        page = self.parent._page
+        """Click TikTok's 'Refresh' panel if it is up.
+
+        In one page.evaluate rather than through select_all('p'), which fetches the whole
+        DOM tree and then walks it once per match -- fine on a freshly loaded page, seconds
+        on a feed that has been scrolled (see _SCROLL_FEED_JS).
+        """
         self.parent.logger.debug("Checking for refresh button")
         try:
-            refresh_button = await self._find_p_element_by_text('Refresh', timeout=1)
-            if refresh_button:
-                self.parent.logger.debug("Refresh button found, clicking")
-                await refresh_button.click()
-                await asyncio.sleep(1)
+            clicked = await self.parent._page.evaluate(_CLICK_REFRESH_JS)
         except Exception:
-            pass
+            return False
+        if clicked:
+            self.parent.logger.debug("Refresh button found, clicking")
+            await asyncio.sleep(1)
+        return bool(clicked)
 
     async def check_and_resolve_login_popup(self):
         page = self.parent._page
@@ -269,6 +510,77 @@ class Base:
         except Exception as e:
             self.parent.logger.debug(f"Error checking login popup: {e}")
 
+
+    async def scroll_feed(self, item_selector=None, container_selector=None):
+        """Advance an infinite-scroll feed by one round.
+
+        Returns the page's own account of what happened: how many items the feed now
+        holds, whether the scroll moved anything, whether we are pinned to the bottom,
+        and whether a Refresh panel or login modal had to be cleared. `atBottom` and
+        `moved` are what let a caller tell 'the feed is slow' from 'the feed cannot
+        load any more without being nudged' -- see _NUDGE_FEED_JS.
+        """
+        js = _SCROLL_FEED_JS % {
+            'items': json.dumps(item_selector) if item_selector else 'null',
+            'container': json.dumps(container_selector) if container_selector else 'null',
+            'refresh': _CLICK_REFRESH_JS_BODY,
+        }
+        try:
+            state = await self.parent._page.evaluate(js)
+        except Exception as ex:
+            self.parent.logger.debug(f"Scroll round failed: {ex}")
+            return {}
+        return state if isinstance(state, dict) else {}
+
+    async def nudge_feed(self, container_selector=None):
+        """Scroll back up so the next scroll down can re-trigger pagination."""
+        js = _NUDGE_FEED_JS % {
+            'container': json.dumps(container_selector) if container_selector else 'null',
+        }
+        try:
+            await self.parent._page.evaluate(js)
+            return True
+        except Exception as ex:
+            self.parent.logger.debug(f"Feed nudge failed: {ex}")
+            return False
+
+    async def await_api_responses(self, url_pattern, timeout=SCROLL_RESPONSE_TIMEOUT,
+                                  poll=SCROLL_POLL_INTERVAL):
+        """Wait for the listing responses a scroll asked for, returning as soon as they land.
+
+        Returns (responses, requested). `requested` records whether the page had such a
+        request in flight (or already collected) at any point during the wait, which is
+        the difference between a response that is merely slow and a feed whose own
+        pagination never fired -- the two need opposite remedies, and a flat sleep
+        cannot tell them apart.
+        """
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        deadline = started + timeout
+        requested = False
+        while True:
+            # before process_pending_responses, which consumes what it matches
+            requested = requested or bool(self.parent.seen_request_urls(url_pattern))
+            responses = await self.parent.process_pending_responses(url_pattern)
+            if responses:
+                return responses, True
+            now = loop.time()
+            if now >= deadline:
+                return [], requested
+            if not requested and now >= started + SCROLL_SILENT_GRACE:
+                # the page has not asked for anything, so no response is on its way and
+                # the rest of the timeout would be spent waiting for one that never comes
+                return [], False
+            await asyncio.sleep(poll)
+
+    def scroll_round_floor(self):
+        """Minimum spacing between the starts of two scroll rounds, jittered.
+
+        Measured from the start of a round rather than slept at the end of one, so a
+        caller that spends time on each video (downloading it, say) pays this out of
+        time it was going to spend anyway instead of on top of it.
+        """
+        return SCROLL_MIN_ROUND + random.uniform(0, SCROLL_ROUND_JITTER)
 
     async def wait_for_content_or_unavailable_or_captcha(self, content_tag, unavailable_text, no_content_text=None):
         if await self._is_selector_visible(content_tag):

--- a/pytok/api/hashtag.py
+++ b/pytok/api/hashtag.py
@@ -36,6 +36,11 @@ def _apostrophe_variants(texts):
     return variants
 
 
+# The hashtag feed's items, used both to wait for the feed and to report how far it
+# has grown during a scroll walk.
+CHALLENGE_ITEM_SELECTOR = '[data-e2e=challenge-item]'
+
+
 class Hashtag(Base):
     """
     A TikTok Hashtag/Challenge.
@@ -169,7 +174,7 @@ class Hashtag(Base):
 
         try:
             await self.wait_for_content_or_unavailable_or_captcha(
-                '[data-e2e=challenge-item]',
+                CHALLENGE_ITEM_SELECTOR,
                 'Not available',
                 no_content_text=_apostrophe_variants(HASHTAG_NOT_FOUND_TEXTS),
             )
@@ -499,7 +504,7 @@ class Hashtag(Base):
         await self.check_and_wait_for_captcha()
         await self.check_and_close_signin()
         await self._raise_if_hashtag_missing()
-        if not await self._is_selector_visible('[data-e2e=challenge-item]'):
+        if not await self._is_selector_visible(CHALLENGE_ITEM_SELECTOR):
             self.parent.logger.warning(
                 "Hashtag video grid not visible yet (TikTok requires login for this "
                 "feed; pass a logged-in user_data_dir if you get no results)."
@@ -514,7 +519,6 @@ class Hashtag(Base):
         API route can't take over. Returns (items, has_more, cursor) so pagination
         continues from where the page's own requests left off.
         """
-        page = self.parent._page
         items = []
         has_more = True
         cursor = 0
@@ -548,7 +552,7 @@ class Hashtag(Base):
             if not has_more or attempt == attempts - 1:
                 break
             await self.check_and_wait_for_captcha()
-            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
+            await self.scroll_feed(CHALLENGE_ITEM_SELECTOR)
             await asyncio.sleep(2.5)
 
         return items, has_more, cursor
@@ -576,57 +580,27 @@ class Hashtag(Base):
 
     async def _scroll_for_videos(self):
         """Scroll the loaded hashtag page, yielding videos from each new response."""
-        page = self.parent._page
+        yielded = 0
+        walk = self.scroll_walk("api/challenge/item_list", CHALLENGE_ITEM_SELECTOR,
+                                before_round=self.check_and_wait_for_captcha)
+        try:
+            async for rnd in walk.rounds():
+                for resp in rnd.responses:
+                    res = self._parse_response(resp)
+                    if res is None:
+                        walk.stats['unusable_responses'] += 1
+                        continue
 
-        has_more = True
-        scroll_attempts = 0
-        max_scroll_attempts = 30
-        empty_rounds = 0
-        max_empty_rounds = 5
+                    videos = res.get("itemList", [])
+                    rnd.produced += len(videos)
+                    for video in videos:
+                        yielded += 1
+                        yield self.parent.video(data=video)
 
-        while has_more and scroll_attempts < max_scroll_attempts:
-            await self.check_and_wait_for_captcha()
-
-            # Scroll first so the lazily-loaded item_list request fires, then give
-            # its response body time to be captured before reading it.
-            yielded_this_round = 0
-            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
-            await asyncio.sleep(3)
-            await self.check_and_resolve_refresh_button()
-
-            video_responses = await self.parent.process_pending_responses("api/challenge/item_list")
-            for resp in video_responses:
-                res = self._parse_response(resp)
-                if res is None:
-                    continue
-
-                for video in res.get("itemList", []):
-                    yielded_this_round += 1
-                    yield self.parent.video(data=video)
-
-                if not res.get("hasMore", False):
-                    self.parent.logger.info(
-                        "TikTok isn't sending more TikToks beyond this point."
-                    )
-                    has_more = False
-
-            if not has_more:
-                break
-
-            # Give up early if scrolling stops producing new videos (e.g. the
-            # feed is login-walled) rather than scrolling to the hard limit.
-            if yielded_this_round == 0:
-                empty_rounds += 1
-                if empty_rounds >= max_empty_rounds:
-                    self.parent.logger.info(
-                        "No new hashtag videos after repeated scrolls, stopping."
-                    )
-                    return
-            else:
-                empty_rounds = 0
-
-            await self.parent.request_delay()
-            scroll_attempts += 1
+                    if 'hasMore' in res:
+                        rnd.stop = not res['hasMore']
+        finally:
+            self.parent.logger.info(f"#{self.name}: walked {yielded} videos, {walk.summary()}")
 
     def __extract_from_data(self):
         data = self.as_dict

--- a/pytok/api/search.py
+++ b/pytok/api/search.py
@@ -20,21 +20,15 @@ if TYPE_CHECKING:
 # web_search_code mirrors what the TikTok web app sends with search requests
 _WEB_SEARCH_CODE = '{"tiktok":{"client_params_x":{"search_engine":{"ies_mt_user_live_video_card_use_libra":1,"mt_search_general_user_live_card":1}},"search_server":{}}}'
 
-# TikTok's search results render inside an inner scroll container, not the
-# document body — so window.scrollBy does nothing. Scroll that container to
-# fire the lazily-loaded pagination requests. Fall back to the window in case
-# the layout changes.
-_SCROLL_SEARCH_GRID_JS = """
-(() => {
-  const el = document.querySelector('#grid-main') ||
-             document.querySelector('[class*=SearchGridLayoutContainer]');
-  if (el && el.scrollHeight > el.clientHeight) {
-    el.scrollTop = el.scrollHeight;
-    return;
-  }
-  window.scrollBy(0, window.innerHeight * 4);
-})()
-"""
+# TikTok's search results render inside an inner scroll container, not the document
+# body -- so scrolling the window does nothing and never fires the lazily-loaded
+# pagination requests. base.scroll_feed falls back to the window if this is not
+# found, in case the layout changes.
+_SEARCH_GRID_SELECTOR = '#grid-main, [class*=SearchGridLayoutContainer]'
+
+# Scrolls with no `count` to size them are only ended by the walk's stall check; this is
+# just a backstop against a page that never stops producing.
+_UNBOUNDED_MAX_ROUNDS = 400
 
 # Page size TikTok serves videos at. User search pages come 20 at a time, so
 # this is only used to size scroll budgets — as the smaller of the two it can
@@ -345,7 +339,6 @@ class Search(Base):
         so pagination continues from where the page's own requests left off. Each
         result is a (object, id) pair as produced by _yield_results.
         """
-        page = self.parent._page
         results = []
         has_more = True
         cursor = 0
@@ -389,7 +382,7 @@ class Search(Base):
             if not has_more or attempt == attempts - 1:
                 break
             await self.check_and_wait_for_captcha()
-            await page.evaluate(_SCROLL_SEARCH_GRID_JS)
+            await self.scroll_feed(container_selector=_SEARCH_GRID_SELECTOR)
             await asyncio.sleep(2.5)
 
         return results, has_more, cursor, search_id
@@ -432,78 +425,49 @@ class Search(Base):
 
         `count` is how many results the caller still needs; it sizes the scroll
         budget, since the page hands back one page of results per scroll. None
-        means the caller wants the whole listing, so no budget is imposed and
-        stopping is left to has_more and the empty-round guard.
+        means the caller wants the whole listing, so stopping is left to has_more
+        and the walk's stall check.
         """
-        page = self.parent._page
+        # One scroll yields one page, so a fixed budget silently caps big requests. Allow
+        # enough scrolls for `count` with slack for rounds that come back empty, and let the
+        # walk's stall check stop us early. count=None asks for everything, so there is no
+        # budget to size -- then only the stall check ends the scroll.
+        max_rounds = (_UNBOUNDED_MAX_ROUNDS if count is None
+                      else max(30, math.ceil(count / _VIDEO_PAGE_SIZE) * 2))
+        yielded = 0
+        # The results live in an inner scroll container, not the window: scrolling the
+        # window there is a no-op that never triggers the infinite-scroll observer.
+        walk = self.scroll_walk(_endpoint_path(obj_type),
+                                container_selector=_SEARCH_GRID_SELECTOR,
+                                max_rounds=max_rounds,
+                                before_round=self.check_and_wait_for_captcha)
+        try:
+            async for rnd in walk.rounds():
+                for resp in rnd.responses:
+                    res = self._parse_response(resp)
+                    if res is None:
+                        walk.stats['unusable_responses'] += 1
+                        continue
 
-        has_more = True
-        scroll_attempts = 0
-        # One scroll yields one page, so a fixed budget silently caps big
-        # requests. Allow enough scrolls for `count` with slack for rounds that
-        # come back empty, and let the empty-round guard below stop us early.
-        # count=None asks for everything, so there is no budget to size -- the
-        # empty-round guard is what ends an unbounded scroll.
-        max_scroll_attempts = None if count is None else max(30, math.ceil(count / _VIDEO_PAGE_SIZE) * 2)
-        empty_rounds = 0
-        max_empty_rounds = 3
+                    results = list(self._yield_results(obj_type, res, with_id=True))
+                    rnd.produced += len(results)
+                    for result in results:
+                        yielded += 1
+                        yield result
 
-        while has_more and (max_scroll_attempts is None or scroll_attempts < max_scroll_attempts):
-            await self.check_and_wait_for_captcha()
-
-            # Scroll first so the lazily-loaded search request fires, then give
-            # its response body time to be captured before reading it. The
-            # results live in an inner scroll container (#grid-main), not the
-            # window — scrolling the window is a no-op and never triggers the
-            # infinite-scroll observer, so target the container.
-            yielded_this_round = 0
-            await page.evaluate(_SCROLL_SEARCH_GRID_JS)
-            await asyncio.sleep(3)
-            await self.check_and_resolve_refresh_button()
-
-            responses = await self.parent.process_pending_responses(_endpoint_path(obj_type))
-            for resp in responses:
-                res = self._parse_response(resp)
-                if res is None:
-                    continue
-
-                page_size = 0
-                for result in self._yield_results(obj_type, res, with_id=True):
-                    page_size += 1
-                    yielded_this_round += 1
-                    yield result
-
-                # Only a short page is trusted when it says the listing is over
-                # (see _note_page_size). An empty or exactly-full page saying the
-                # same is as likely to be TikTok stalling us, so leave those to
-                # the empty-round guard below, which gives the page a couple more
-                # scrolls to recover.
-                short_page = self._note_page_size(page_size)
-                if not res.get("has_more", 0) and short_page:
-                    self.parent.logger.info(
-                        f"TikTok is not sending results beyond this point "
-                        f"(last page held {page_size})."
-                    )
-                    self._exhausted_listing = True
-                    has_more = False
-
-            if not has_more:
-                break
-
-            # Give up early if scrolling stops producing new results rather than
-            # scrolling all the way to the hard limit.
-            if yielded_this_round == 0:
-                empty_rounds += 1
-                if empty_rounds >= max_empty_rounds:
-                    self.parent.logger.info(
-                        "No new search results after repeated scrolls, stopping."
-                    )
-                    return
-            else:
-                empty_rounds = 0
-
-            await self.parent.request_delay()
-            scroll_attempts += 1
+                    # Only a short page is trusted when it says the listing is over (see
+                    # _note_page_size). An empty or exactly-full page saying the same is as
+                    # likely to be TikTok stalling us, so leave those to the walk's stall
+                    # check, which gives the page a few more scrolls to recover.
+                    short_page = self._note_page_size(len(results))
+                    if not res.get("has_more", 0) and short_page:
+                        self._exhausted_listing = True
+                        rnd.stop = True
+        finally:
+            self.parent.logger.info(
+                f"search {obj_type} '{self.search_term}': walked {yielded} results, "
+                f"{walk.summary()}"
+            )
 
     def _yield_results(self, obj_type, res, with_id=False):
         """Build User/Video objects from a search response payload."""

--- a/pytok/api/sound.py
+++ b/pytok/api/sound.py
@@ -19,6 +19,11 @@ from ..exceptions import *
 from ..helpers import extract_tag_contents
 
 
+# The sound feed's items, used both to wait for the feed and to report how far it has
+# grown during a scroll walk.
+MUSIC_ITEM_SELECTOR = '[data-e2e=music-item]'
+
+
 class Sound(Base):
     """
     A TikTok Sound/Music/Song.
@@ -130,7 +135,7 @@ class Sound(Base):
 
         if music_info is None:
             await self.wait_for_content_or_unavailable_or_captcha(
-                '[data-e2e=music-item]', 'Not available'
+                MUSIC_ITEM_SELECTOR, 'Not available'
             )
             await self.check_and_close_signin()
 
@@ -395,7 +400,7 @@ class Sound(Base):
         await self._navigate_to_sound_page()
         await self.check_and_wait_for_captcha()
         await self.check_and_close_signin()
-        if not await self._is_selector_visible('[data-e2e=music-item]'):
+        if not await self._is_selector_visible(MUSIC_ITEM_SELECTOR):
             self.parent.logger.warning(
                 "Sound video grid not visible yet (TikTok requires login for this "
                 "feed; pass a logged-in user_data_dir if you get no results)."
@@ -410,7 +415,6 @@ class Sound(Base):
         API route can't take over. Returns (items, has_more, cursor) so pagination
         continues from where the page's own requests left off.
         """
-        page = self.parent._page
         items = []
         has_more = True
         cursor = 0
@@ -444,7 +448,7 @@ class Sound(Base):
             if not has_more or attempt == attempts - 1:
                 break
             await self.check_and_wait_for_captcha()
-            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
+            await self.scroll_feed(MUSIC_ITEM_SELECTOR)
             await asyncio.sleep(2.5)
 
         return items, has_more, cursor
@@ -472,57 +476,29 @@ class Sound(Base):
 
     async def _scroll_for_videos(self):
         """Scroll the loaded sound page, yielding videos from each new response."""
-        page = self.parent._page
+        yielded = 0
+        walk = self.scroll_walk("api/music/item_list", MUSIC_ITEM_SELECTOR,
+                                before_round=self.check_and_wait_for_captcha)
+        try:
+            async for rnd in walk.rounds():
+                for resp in rnd.responses:
+                    res = self._parse_response(resp)
+                    if res is None:
+                        walk.stats['unusable_responses'] += 1
+                        continue
 
-        has_more = True
-        scroll_attempts = 0
-        max_scroll_attempts = 30
-        empty_rounds = 0
-        max_empty_rounds = 5
+                    videos = res.get("itemList", [])
+                    rnd.produced += len(videos)
+                    for video in videos:
+                        yielded += 1
+                        yield self.parent.video(data=video)
 
-        while has_more and scroll_attempts < max_scroll_attempts:
-            await self.check_and_wait_for_captcha()
-
-            # Scroll first so the lazily-loaded item_list request fires, then give
-            # its response body time to be captured before reading it.
-            yielded_this_round = 0
-            await page.evaluate('window.scrollBy(0, window.innerHeight * 4)')
-            await asyncio.sleep(3)
-            await self.check_and_resolve_refresh_button()
-
-            video_responses = await self.parent.process_pending_responses("api/music/item_list")
-            for resp in video_responses:
-                res = self._parse_response(resp)
-                if res is None:
-                    continue
-
-                for video in res.get("itemList", []):
-                    yielded_this_round += 1
-                    yield self.parent.video(data=video)
-
-                if not res.get("hasMore", False):
-                    self.parent.logger.info(
-                        "TikTok isn't sending more TikToks beyond this point."
-                    )
-                    has_more = False
-
-            if not has_more:
-                break
-
-            # Give up early if scrolling stops producing new videos (e.g. the
-            # feed is login-walled) rather than scrolling to the hard limit.
-            if yielded_this_round == 0:
-                empty_rounds += 1
-                if empty_rounds >= max_empty_rounds:
-                    self.parent.logger.info(
-                        "No new sound videos after repeated scrolls, stopping."
-                    )
-                    return
-            else:
-                empty_rounds = 0
-
-            await self.parent.request_delay()
-            scroll_attempts += 1
+                    if 'hasMore' in res:
+                        rnd.stop = not res['hasMore']
+        finally:
+            self.parent.logger.info(
+                f"sound {self.id}: walked {yielded} videos, {walk.summary()}"
+            )
 
     def __extract_from_data(self):
         data = self.as_dict or {}

--- a/pytok/api/user.py
+++ b/pytok/api/user.py
@@ -22,6 +22,10 @@ from .base import Base
 # Only consulted when TikTok never said the listing ended -- see _iter_videos.
 LISTING_MIN_COVERAGE = 0.9
 
+# The profile grid's items, which is both what we wait for on load and how a scroll round
+# reports how far the grid has grown.
+POST_ITEM_SELECTOR = '[data-e2e="user-post-item"]'
+
 
 class User(Base):
     """
@@ -234,7 +238,7 @@ class User(Base):
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
         await self.wait_for_content_or_unavailable_or_captcha(
-            '[data-e2e="user-post-item"]',
+            POST_ITEM_SELECTOR,
             "Couldn't find this account",
             no_content_text=["No content", "This account is private", "Log in to TikTok"]
         )
@@ -536,7 +540,7 @@ class User(Base):
 
         # Wait for video items using base class method (handles refresh button, captcha, login popup)
         await self.wait_for_content_or_unavailable_or_captcha(
-            '[data-e2e="user-post-item"]',
+            POST_ITEM_SELECTOR,
             "Couldn't find this account",
             no_content_text=["No content", "This account is private", "Log in to TikTok"]
         )
@@ -683,85 +687,77 @@ class User(Base):
         return all_videos, finished, cursor
 
     async def _get_videos_scroll(self, count, seen_ids=None, amount_yielded=0):
-        """Scroll to load more videos using zendriver.
+        """Scroll the profile page, yielding videos out of each item_list response.
 
         Most walks end up here, because item_list is the route TikTok blocks first, so how
         this loop decides to stop sets how deep a walk can get. Two of its stopping
         conditions used to be indistinguishable from reaching the end of a profile; only this
         loop knows which one fired, so it records that in `_listing_exhausted`.
+
+        Each round is one page.evaluate and a wait for the response that scroll asked for.
+        Nothing here may reach for zendriver's element API: its cost grows with the square
+        of the grid, which set the real ceiling on how deep a walk could get (see
+        base._SCROLL_FEED_JS). Waiting for the response rather than sleeping a flat
+        interval is what makes a round cost what the network costs, and it also says
+        whether the page asked for a page at all -- a feed that stopped asking needs
+        nudging, not more patience.
         """
-        page = self.parent._page
         if seen_ids is None:
             seen_ids = set()
 
-        has_more = True
-        scroll_attempts = 0
         # A bounded walk stops at `count` anyway; an unbounded one wants the whole profile,
-        # which 30 scrolls caps at a few hundred videos. The no-new-videos check below is the
-        # real terminator, so this is only a backstop against scrolling a page that never ends.
-        max_scroll_attempts = 30 if count else 400
-        no_new_videos_count = 0
-        last_video_count = amount_yielded
+        # which 30 scrolls caps at a few hundred videos. The walk's own stall check is the
+        # real terminator, so this is only a backstop against a page that never ends.
+        walk = self.scroll_walk('api/post/item_list', POST_ITEM_SELECTOR,
+                                max_rounds=30 if count else 400)
+        try:
+            async for rnd in walk.rounds():
+                fresh = []
+                for resp in rnd.responses:
+                    body = resp.get('body') or ''
+                    if not body:
+                        # A bot-blocked listing is a 200 with nothing in it. Tallied rather
+                        # than passed over in silence, because it is the signal that tells a
+                        # short walk that was blocked from one that was finished.
+                        walk.stats['empty_listing_responses'] += 1
+                        continue
+                    try:
+                        data = json.loads(body) if isinstance(body, str) else body
+                    except Exception as ex:
+                        walk.stats['unparseable_responses'] += 1
+                        self.parent.logger.debug(f"Error processing video response: {ex}")
+                        continue
 
-        while scroll_attempts < max_scroll_attempts and has_more:
-            # Scroll down
-            await page.evaluate('window.scrollBy(0, window.innerHeight * 3)')
-            await asyncio.sleep(2)
-
-            # Check for refresh button that may appear during scrolling
-            await self.check_and_resolve_refresh_button()
-
-            # Process any pending responses
-            video_responses = await self.parent.process_pending_responses('api/post/item_list')
-
-            for resp in video_responses:
-                body = resp.get('body', '')
-                if not body:
-                    continue
-
-                try:
-                    data = json.loads(body) if isinstance(body, str) else body
-                    item_list = data.get('itemList', [])
-                    for item in item_list:
+                    for item in data.get('itemList', []):
                         video_id = item.get('id')
                         if video_id and video_id not in seen_ids:
                             seen_ids.add(video_id)
-                            amount_yielded += 1
-                            yield self.parent.video(data=item)
-
-                            if count and amount_yielded >= count:
-                                return
+                            fresh.append(item)
 
                     # Only believe hasMore when TikTok actually sent it. Defaulting to False
                     # ended the walk on any response arriving without it -- which is what an
                     # empty bot-blocked body looks like.
                     if 'hasMore' in data:
-                        has_more = data['hasMore']
-                except Exception as e:
-                    self.parent.logger.debug(f"Error processing video response: {e}")
+                        rnd.stop = not data['hasMore']
 
-            current_count = amount_yielded
-            if current_count == last_video_count:
-                no_new_videos_count += 1
-                if no_new_videos_count >= 5:
-                    self.parent.logger.info("No new videos found after multiple scrolls, stopping")
-                    break
-            else:
-                no_new_videos_count = 0
+                rnd.produced = len(fresh)
+                for item in fresh:
+                    amount_yielded += 1
+                    yield self.parent.video(data=item)
+                    if count and amount_yielded >= count:
+                        walk.reason = 'reached the requested count'
+                        return
 
-            last_video_count = current_count
-            scroll_attempts += 1
-
-        # Only a hasMore=false answer means the profile ran out. Giving up because the page
-        # stopped producing new videos, or because the backstop above ran out of scrolls, is a
-        # walk that was cut off -- _iter_videos raises on that so the pool retries the handle
-        # on a fresh session instead of recording a partial profile as fully collected.
-        if not has_more:
-            self._listing_exhausted = True
-        else:
+            # Only a hasMore=false answer means the profile ran out. Giving up because the
+            # page stopped producing new videos, or because the backstop above ran out of
+            # scrolls, is a walk that was cut off -- _iter_videos raises on that so the pool
+            # retries the handle on a fresh session instead of recording a partial profile as
+            # fully collected.
+            if walk.listing_ended:
+                self._listing_exhausted = True
+        finally:
             self.parent.logger.info(
-                f"Stopped scrolling @{self.username} after {scroll_attempts} scrolls with "
-                f"{amount_yielded} videos while TikTok still reported more available"
+                f"@{self.username}: walked {amount_yielded} videos, {walk.summary()}"
             )
 
     def liked(self, count: int = 30, cursor: int = 0, **kwargs) -> Iterator[Video]:


### PR DESCRIPTION
Two commits. The first replaces the per-round DOM work that was capping how deep any walk could get and consolidates four copies of the scroll loop into one; the second fixes a misleading stop reason it exposed.

## The element API was the ceiling, not TikTok

Every scroll round called `check_and_resolve_refresh_button`, which goes through zendriver's `select_all('p')`. That fetches the whole DOM tree over CDP and then walks that tree once per match (`core/tab.py query_selector_all`), so its cost grows with the square of the feed.

Measured against a synthetic grid in headless Chrome, one call costs:

| grid items | one call |
|---|---|
| 30 | 20ms |
| 300 | 483ms |
| 600 | 2.0s |
| 1000 | 6.6s |
| 2000 | 31.6s |

Charged once per round, on top of a flat 2s sleep. The deeper a walk got the more of its time went on bookkeeping, which is what actually bounded walk depth. The same work in `page.evaluate` is 3–14ms at any feed size.

## What a round is now

One `page.evaluate` that does everything the round needs from the page — scroll the element that actually scrolls, clear a Refresh panel or login modal, report `items`/`moved`/`atBottom` — followed by a wait for the response that scroll asked for. The wait returns as soon as the response lands instead of sleeping a fixed interval, so a round costs what the network costs.

`_pending_requests` also tells us whether the page asked for a page *at all*. A feed that has stopped asking needs nudging, not more patience: five no-op scrolls at the bottom used to end a walk in ~10s with no recovery attempted. Once a feed is pinned to its bottom, scrolling down again is a no-op and the sentinel that triggers the next page cannot re-enter the viewport, so the only way to re-arm it is to pull back up.

## One policy instead of four copies

The four feeds (user, hashtag, search, sound) were four copies of the same loop, so the policy lives once in `base.ScrollWalk` now and each feed only interprets its own payload.

A walk ends on `hasMore`/`has_more`, or on a stall of 25s over 5 rounds — capped at 20 rounds, since rounds that come back fast would never fill the seconds. `listing_ended` keeps "the feed said it was done" distinguishable from "we gave up", which callers need in order to tell a finished walk from a truncated one.

This also fixes a real bug in two of the feeds: **hashtag and sound defaulted `hasMore` to `False`**, which ended a walk on any response arriving without it — which is exactly what an empty bot-blocked body looks like.

Container auto-detection only engages when the document does not scroll at all, so today's pages scroll exactly as they did; search keeps its explicit `#grid-main`.

## Observability

Each walk logs one line: items walked, scrolls, seconds, feed size, empty (bot-blocked) responses, rounds the page asked for nothing, nudges, panels cleared, and why it stopped.

That is what made #41 diagnosable at all — before it, a short catalogue whose listing was never fetched was indistinguishable from a bot-blocked one.

## Second commit: don't report an abandoned walk as an exhausted budget

`reason` defaulted to `'ran out of scrolls'`, which also stood when the caller closed the generator — a date window it had walked past, a session it had given up on, or the run being stopped. A test run showed two walks reporting they had run out of scrolls after 54 and 55 of a 400 budget, which reads as a limit worth raising rather than as work that was abandoned mid-walk. The budget message is now set only where the loop actually falls out of its `while`, and it names the budget it hit.

## Note on #42

[#42](https://github.com/MEOMcGill/pytok/pull/42) is also based on `master` and touches `base.py` and `user.py`. I checked with `git merge-tree` — the two merge cleanly in either order, no rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
