### PR TITLE
Don't let a hung session teardown wedge the whole pool

### DIFF
--- a/pytok/accounts/pool.py
+++ b/pytok/accounts/pool.py
@@ -269,7 +269,15 @@ class AccountsPool:
         q = f"SELECT username FROM accounts WHERE {self._id_cond(username)} AND in_use = false"
         return await self._get_and_mark_in_use(q)
 
-    async def get_available_or_wait(self, poll: float = 5.0) -> Account | None:
+    async def get_available_or_wait(self, poll: float = 5.0,
+                                    remind_after: float = 300.0) -> Account | None:
+        """Wait for an account to come free, reporting periodically while it doesn't.
+
+        The reminder matters more than it looks: a wait past the longest cooldown means
+        something is holding an account it will never give back, and a wait logged once is
+        indistinguishable in the log from a run that finished quietly.
+        """
+        waited = 0.0
         msg_shown = False
         while True:
             account = await self.get_available()
@@ -281,15 +289,24 @@ class AccountsPool:
             if self._raise_when_no_account:
                 raise NoAccountError("No account available")
 
-            if not msg_shown:
+            if not msg_shown or waited >= remind_after:
                 nat = await self.next_available_at()
-                if not nat:
+                if not nat and not msg_shown:
                     logger.warning("No active accounts. Stopping...")
                     return None
-                logger.info(f"No account available. Next available at {nat}")
+                if msg_shown:
+                    stats = await self.stats()
+                    logger.warning(
+                        f"Still no account after {waited / 60:.0f}m (next available "
+                        f"{nat or 'never'}); pool: {stats}"
+                    )
+                else:
+                    logger.info(f"No account available. Next available at {nat}")
                 msg_shown = True
+                waited = 0.0
 
             await asyncio.sleep(poll)
+            waited += poll
 
     async def next_available_at(self):
         qs = """

--- a/pytok/accounts/worker.py
+++ b/pytok/accounts/worker.py
@@ -67,6 +67,12 @@ RATE_LIMIT_MINUTES = 15
 # page that will not finish loading for this session -- otherwise repeats it on every
 # handle forever, pinning the worker to one account.
 MAX_INPLACE_REBUILDS = 3
+# How long a session teardown may take before it is abandoned. Every CDP call awaits its
+# reply on an unbounded future, so a browser that dies mid-teardown can hang shutdown for
+# good -- and with it the worker, which then never reaches the release in rotate_account and
+# leaves its account marked in_use with nothing able to reclaim it. Abandoning the teardown
+# may orphan the browser process, which is the lesser loss.
+SESSION_CLOSE_TIMEOUT = 30
 
 
 class Worker:
@@ -296,29 +302,42 @@ class Worker:
         cooldown expires (via get_available_or_wait), giving the periodic-rest
         behaviour rather than crashing.
         """
-        await self._close_session()
-        if self.current_account:
-            await self.pool.lock_until(
-                self.current_account.username,
-                f"datetime('now', '+{cooldown_minutes} minutes')",
-            )
-            await self.pool.release_account(self.current_account.username)
-            logger.info(f"Worker {self.id} rested {self.current_account.username} "
-                        f"({cooldown_minutes}m)")
-            self.current_account = None
-        self.tasks_done = 0
-        self._initialized = False
+        # The cooldown and release run whatever the teardown did: a worker that cannot
+        # close its browser must still give the account back, or the account stays in_use
+        # and no worker -- this one included -- can ever be handed it again.
+        try:
+            await self._close_session()
+        finally:
+            if self.current_account:
+                await self.pool.lock_until(
+                    self.current_account.username,
+                    f"datetime('now', '+{cooldown_minutes} minutes')",
+                )
+                await self.pool.release_account(self.current_account.username)
+                logger.info(f"Worker {self.id} rested {self.current_account.username} "
+                            f"({cooldown_minutes}m)")
+                self.current_account = None
+            self.tasks_done = 0
+            self._initialized = False
 
         if not await self._acquire(wait=True):
             raise NoAccountError(f"Worker {self.id}: no account for rotation")
 
     async def _close_session(self):
-        if self.api is not None:
-            try:
-                await self.api.shutdown()  # release_on_shutdown=False: keeps account
-            except Exception:
-                pass
-            self.api = None
+        if self.api is None:
+            return
+        # Drop the reference first, so an abandoned teardown can't be re-entered by the
+        # rebuild that follows.
+        api, self.api = self.api, None
+        try:
+            # release_on_shutdown=False: keeps the account
+            await asyncio.wait_for(api.shutdown(), timeout=SESSION_CLOSE_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.error(f"Worker {self.id}: session teardown for {self._acct_name()} did "
+                         f"not finish in {SESSION_CLOSE_TIMEOUT}s; abandoning it (the "
+                         f"browser process may be left running)")
+        except Exception:
+            pass
 
     async def _release_current(self):
         if self.current_account:

--- a/tests/test_accounts_worker.py
+++ b/tests/test_accounts_worker.py
@@ -1,0 +1,96 @@
+"""Worker/pool teardown behaviour, on a temporary accounts DB and a fake session.
+
+Offline: no browser, no network. Async bodies are driven with asyncio.run so the suite
+needs no pytest-asyncio.
+"""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+from pytok.accounts import AccountsPool
+from pytok.accounts import worker as worker_mod
+from pytok.accounts.worker import Worker
+
+
+class HangingSession:
+    """A session whose teardown never returns, as a dead browser's does."""
+
+    async def shutdown(self):
+        await asyncio.Event().wait()
+
+
+async def _pool_with_one_account():
+    db_file = os.path.join(tempfile.mkdtemp(), "accounts.db")
+    pool = AccountsPool(db_file=db_file)
+    await pool.add_account("acct-a", cookies="sid=1")
+    await pool.set_active("acct-a", True)
+    return pool
+
+
+def test_hung_teardown_still_releases_the_account(monkeypatch):
+    """A worker that cannot close its browser must not keep the account.
+
+    The account is only reclaimable through the release in rotate_account, so a teardown
+    that hangs there takes the whole pool down with it: every worker then waits on an
+    account nothing will ever hand back.
+    """
+
+    monkeypatch.setattr(worker_mod, "SESSION_CLOSE_TIMEOUT", 2)
+
+    async def scenario():
+        pool = await _pool_with_one_account()
+        worker = Worker(id="worker-test", pool=pool)
+        assert await worker._acquire()
+        assert (await pool.stats())["in_use"] == 1
+        worker.api = HangingSession()
+
+        # rotate_account re-acquires at the end; stub that out to isolate the release
+        async def no_reacquire(wait=False):
+            return False
+
+        worker._acquire = no_reacquire
+
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        with pytest.raises(worker_mod.NoAccountError):
+            await asyncio.wait_for(worker.rotate_account(cooldown_minutes=0), timeout=20)
+        elapsed = loop.time() - started
+
+        assert elapsed < 10, "the teardown was waited on instead of abandoned"
+        assert (await pool.stats())["in_use"] == 0, "account left in_use"
+        assert worker.api is None
+
+        await asyncio.sleep(1.5)  # let the 0-minute cooldown lapse
+        assert await pool.get_available_or_wait(poll=0.2) is not None
+
+    asyncio.run(scenario())
+
+
+def test_waiting_for_an_account_keeps_reporting(caplog):
+    """A wait that outlives every cooldown is a stall, and has to look like one.
+
+    Reported once, it is indistinguishable in the log from a run that finished quietly.
+    """
+
+    async def scenario():
+        pool = await _pool_with_one_account()
+        assert await pool.get_available() is not None       # hold it, in_use
+        await pool.lock_until("acct-a", "datetime('now', '+1 minutes')")
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                pool.get_available_or_wait(poll=0.2, remind_after=0.5), timeout=2
+            )
+
+    with caplog.at_level("WARNING", logger="PyTok"):
+        asyncio.run(scenario())
+
+    reminders = [r for r in caplog.records if "Still no account" in r.message]
+    assert reminders, "a stuck wait reported nothing after the first line"
+    assert "'in_use': 1" in reminders[0].message, "the reminder omits what is holding it"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## The failure

A pooled run on the edge worker went silently dead 28 minutes in and sat that way for ~15 hours, with the Scheduled Task still reporting `Running`.

A worker hit `rotate_account` on a `FewerVideosThanExpectedException`. Its Chrome had already died — zendriver logged *"Could not send the close command when stopping the browser. Likely the browser is already gone"*, which turned out to be the last line the run ever wrote. `PyTok.shutdown()` never returned: every CDP call awaits its reply on a bare future (`return await tx` in zendriver's `Connection.send`), so a dead connection hangs teardown indefinitely.

From there it cascades:

- `rotate_account` released the account only **after** `_close_session()` returned, so the account stayed `in_use` forever. `get_available()` excludes `in_use`, so no worker — including the one holding it — could ever be handed it again.
- `get_available_or_wait` logs `No account available` once and then polls every 5s in silence. Fifteen hours of a wedged pool looked identical in the log to a run that had finished quietly.

The tell, for anyone diagnosing this in the wild: the `Worker X rested <account>` line that should follow a `cooldown + rotate` warning is **missing**, and `cli list` shows one account `In Use` with no live `pytok*profiles` Chrome holding its profile.

## The fix

Three changes, one per link:

1. **`_close_session` bounds the teardown** at `SESSION_CLOSE_TIMEOUT` (30s) and abandons it on timeout. A healthy teardown is a second or two, so anything past this is a dead connection. Abandoning may orphan the browser process — the lesser loss against a worker that never comes back. The `api` reference is dropped before the await so the rebuild that follows cannot re-enter an abandoned teardown.
2. **`rotate_account` cools down and releases in a `finally`.** A worker that cannot close its browser must still give the account back. Kept in this order (close, then release) rather than releasing first, so the account cannot be handed to another worker while this one's browser is still shutting down on the same profile dir.
3. **`get_available_or_wait` re-reports** every `remind_after` seconds (default 300) with `pool.stats()`. A wait outliving the longest cooldown means something is holding an account it will never return, and the stats line is what surfaces `in_use: 1` while everything else is merely locked.

## Tests

`tests/test_accounts_worker.py`, offline — temporary accounts DB, fake session whose `shutdown()` awaits forever, no browser or network:

- `test_hung_teardown_still_releases_the_account` — teardown is abandoned rather than waited on, `in_use` returns to 0, and the pool hands the account out again once the cooldown lapses.
- `test_waiting_for_an_account_keeps_reporting` — a stuck wait keeps logging, and the reminder names what is holding the account.

The suite drives async bodies with `asyncio.run`, so it needs no `pytest-asyncio` (`pytest tests/test_accounts_worker.py` → 2 passed).

## Note

The exact hung `await` is inferred, not captured: the process was killed to free the pool before a stack dump was taken, so the diagnosis rests on the log ordering and the stranded `in_use` flag. The fix does not depend on which await it was — any unbounded teardown produces the same wedge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
